### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,23 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.2.0] - 2026-07-08
+
+First packaged release of SpecLens — a desktop reader for OpenSpec projects.
+
+### Highlights
+
+- **Browse OpenSpec repositories** — add any local folder containing an `openspec/` directory; proposals, tasks, and specs render as rich markdown with GFM, Mermaid diagrams, and EARS keyword highlighting
+- **Seven views** — Overview, Changes, Specs, Flow, Graph, Timeline, and Schemas
+- **Git-derived attribution** — created/edited bylines and timestamps come straight from repo history, with a per-repo cache for fast cold starts
+- **Comments** — select any passage to attach a comment; unresolved/resolved workflow, quote-click jumps back to the highlighted text, persisted locally in SQLite
+- **Navigate quickly** — global search (⌘K), back/forward history (⌘[ / ⌘]), document zoom, and a minimap with a slide-out table of contents
+- **Onboarding tutorial** on first launch, replayable from Settings
+- **Customization** — dark/light theme, drag-resizable sidebar, reading speed, highlight color, and comments panel width
+- **Multi-platform builds** — macOS (Apple Silicon `.dmg`), Linux x64/arm64 (`.AppImage`, `.deb`, `.rpm`), Windows x64 (`.msi`, NSIS) and arm64 (NSIS)
+
+### Known limitations
+
+- Bundles are not code-signed yet; on macOS run `xattr -cr /Applications/SpecLens.app` after installing (see README)
+

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "speclens",
 	"private": true,
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"type": "module",
 	"packageManager": "pnpm@11.4.0",
 	"scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -3730,7 +3730,7 @@ dependencies = [
 
 [[package]]
 name = "speclens"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "serde",
  "serde_json",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "speclens"
-version = "0.1.0"
+version = "0.2.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "SpecLens",
-	"version": "0.1.0",
+	"version": "0.2.0",
 	"identifier": "com.danielreis.speclens",
 	"build": {
 		"beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
First packaged release. Bumps the version to 0.2.0 in package.json, tauri.conf.json, Cargo.toml/Cargo.lock and adds the curated CHANGELOG.

Merging this triggers the Release workflow: five parallel builds (macOS arm64, Linux x64/arm64, Windows x64/arm64) whose bundles get attached to the v0.2.0 GitHub release.