### PR TITLE
chore: release v1.1.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.1.3](https://github.com/dansreis/speclens/compare/v1.1.2...v1.1.3) - 2026-07-14
+
+- Fixed the Linux AppImage failing to start on Wayland with `EGL_BAD_PARAMETER`: the app now preloads the system Wayland client library instead of the bundled one and disables unstable WebKitGTK rendering paths inside AppImages (#13)
+
 ## [1.1.2](https://github.com/dansreis/speclens/compare/v1.1.1...v1.1.2) - 2026-07-13
 
 - SpecLens now tells you when a newer version is available: a notice on launch, a badge on the About icon, and a link in the About dialog. One request to GitHub per day, and it can be turned off in Settings → General

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "speclens",
 	"private": true,
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"type": "module",
 	"packageManager": "pnpm@11.4.0",
 	"scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "speclens"
-version = "1.1.2"
+version = "1.1.3"
 dependencies = [
  "encoding_rs",
  "git2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "speclens"
-version = "1.1.2"
+version = "1.1.3"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "SpecLens",
-	"version": "1.1.2",
+	"version": "1.1.3",
 	"identifier": "com.danielreis.speclens",
 	"build": {
 		"beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Patch release for the Linux AppImage Wayland EGL fix (#13, PR #14).

- Fixed the Linux AppImage failing to start on Wayland with EGL_BAD_PARAMETER: the app now preloads the system Wayland client library instead of the bundled one and disables unstable WebKitGTK rendering paths inside AppImages

Merging bumps package.json on main, which triggers the Release workflow (build all platforms, tag v1.1.3, publish the GitHub release).