### PR TITLE
Spec checks: deterministic spec linting (Feature 1 of checks-and-claims)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,12 +11,14 @@ Reads OpenSpec projects from local folders at runtime via a Tauri command. Users
 ## Stack decisions
 
 - **MUI + Emotion.** Confirmed UI stack. **Don't add Tailwind.**
-- **Zustand + SQLite write-through (not `persist` middleware).** `useAppStore` holds UI state (theme, sidebar collapse, selected repo/change/tab, scroll target, `markdownZoom`, `highlightEars`) **plus `repoSources: { path, missing }[]`** (the user-added folder list - paths persist, `missing` resets to `false` on cold start) **plus `settings: AppSettings`** (reader preferences - reading wpm, highlight color, comments panel width). Persistence is done manually in `src/store/bootstrap.ts`: `bootstrap()` hydrates from SQLite on start, then `attachWriteThrough()` subscribes to each persisted slice and writes it back (UI keys → `kv_state`, sources → `repo_sources`). The loaded `repos: Repo[]` is **not** persisted - `reloadAllSources()` re-walks each path on mount. `useCommentsStore` also persists via SQLite (`comments` table).
-- **Settings.** `AppSettings` + `DEFAULT_SETTINGS` + `HIGHLIGHT_COLORS` + `sanitizeSettings()` live in `useAppStore.ts`; the whole object persists as one `"settings"` kv blob. Mutate via `setSetting(key, value)` / `resetSettings()`. The dialog is in `src/sidebar/SidebarFooter.tsx`. **To add a setting:** extend the type + defaults, add a validated branch in `sanitizeSettings`, read `s.settings.<key>` at the consumer, add a control to the dialog - no new subscription needed.
-- **Tauri `load_repo(path)` command** in `src-tauri/src/lib.rs` loads one project: walks its `openspec/` subtree, reads markdown + yaml, and (when a `.git/` exists at the project root or its immediate parent - see `find_git_root`) derives `DocAuthorship` per file via the `git2` crate (vendored libgit2 - no git binary needed), following renames like `git log --follow`. The walk is intentionally capped at one level up so that loading a folder from inside an unrelated git checkout (e.g. somewhere under `~`) doesn't pull authorship from that repo. JS calls the command once per source and catches per-source errors to mark `missing: true`. **Git is optional** - when absent, `Change.authorship`, `createdAt`, and `archivedAt` are `null` and the UI degrades gracefully.
-- **Per-repo cold-start cache.** Each `load_repo` response includes a `signature` (git: `HEAD-sha + scoped porcelain status` hash; non-git: hash of `openspec/` file mtimes). The fast Tauri command `repo_signature(path)` returns the signature alone (no file reads). On cold start, `reloadAllSources` fetches the signature first; if it matches the cached entry in SQLite (`repo_cache` table, keyed by path), the saved `Repo` is used as-is - no walking, no git log. Mismatch → full reload + cache overwrite. See `src/lib/repoCache.ts` (thin wrapper over `src/lib/db.ts`). Dates in cached entries get revived (JSON round-trip loses the `Date` type).
+- **Zustand + SQLite write-through (not `persist` middleware).** `useAppStore` holds UI state (theme, sidebar collapse, selected repo/change/tab, scroll target, `markdownZoom`, `highlightEars`, session-only panel state) **plus `repoSources: { path, missing }[]`** (the user-added folder list - paths persist, `missing` resets to `false` on cold start) **plus `settings: AppSettings`**. Persistence is done manually in `src/store/bootstrap.ts`: `bootstrap()` hydrates from SQLite on start, then `attachWriteThrough()` subscribes to each persisted slice and writes it back (UI keys → `kv_state`, sources → `repo_sources`). The loaded `repos: Repo[]` is **not** persisted - `reloadAllSources()` re-walks each path on mount. `useCommentsStore` persists via SQLite (`comments` table). `useAiStore` holds AI generation state + session summary caches.
+- **Settings.** `AppSettings` + `DEFAULT_SETTINGS` + `HIGHLIGHT_COLORS` + `sanitizeSettings()` live in `useAppStore.ts`; the whole object persists as one `"settings"` kv blob. Mutate via `setSetting(key, value)` / `resetSettings()`. The dialog is in `src/sidebar/SidebarFooter.tsx` (General / Reading / AI tabs). **To add a setting:** extend the type + defaults, add a validated branch in `sanitizeSettings`, read `s.settings.<key>` at the consumer, add a control to the dialog - no new subscription needed.
+- **Tauri `load_repo(path)` command** in `src-tauri/src/lib.rs` loads one project: walks its `openspec/` subtree, reads markdown + yaml, and (when a `.git/` exists at the project root or its immediate parent - see `find_git_root`) derives `DocAuthorship` per file via the `git2` crate (vendored libgit2 - no git binary needed). Authorship comes from **one history walk for all files** (`collect_file_histories`) - see "Authorship pipeline". The git-root walk is intentionally capped at one level up so that loading a folder from inside an unrelated git checkout (e.g. somewhere under `~`) doesn't pull authorship from that repo. JS calls the command once per source and catches per-source errors to mark `missing: true`. **Git is optional** - when absent, `Change.authorship`, `createdAt`, and `archivedAt` are `null` and the UI degrades gracefully.
+- **Per-repo cold-start cache.** Each `load_repo` response includes a `signature` (git: `HEAD-sha + scoped porcelain status` hash; non-git: hash of `openspec/` file mtimes). The fast Tauri command `repo_signature(path)` returns the signature alone (no file reads). On cold start, `reloadAllSources` fetches the signature first; if it matches the cached entry in SQLite (`repo_cache` table, keyed by path), the saved `Repo` is used as-is - no walking, no git log. Mismatch → full reload + cache overwrite. See `src/lib/repoCache.ts` (thin wrapper over `src/lib/db.ts`). Dates in cached entries get revived (JSON round-trip loses the `Date` type). `useRepoSyncWatcher` polls the selected repo's signature (15s + window focus) and only *marks* it stale - reload is always user-initiated.
+- **Local AI (`src-tauri/src/ai.rs`).** On-device summaries via llama.cpp (Metal) or an Ollama backend, exposed as `ai_*` commands. Nothing downloads or runs until the user fetches a model, so the no-network promise holds. Prompts are built on the JS side (`src/lib/aiSummary.ts`, `aiDocSummary.ts` - pure, unit-tested); Rust just receives the final string.
+- **Spec checks (deterministic lint).** `src/lib/specChecks.ts` is the engine (structural SL00x errors, consistency SL01x warnings, language SL02x checks); `src/lib/specChecksConfig.ts` is the registry - ids, severities, titles, message templates, and word lists all live there, the engine holds only detection logic. Both modules must stay pure (no Tauri imports) so the lint core can be extracted into a CLI later (see `docs/design/checks-and-claims.md`). Surfaced as a right-side results panel, list badges, and in-document wavy underlines with hover diagnostics. `settings.specChecks` (default on) gates all computation.
 - **`@tauri-apps/plugin-dialog`** powers the "Add repository" folder picker (capability `dialog:default`).
-- **No i18n** - deferred. Tests: Vitest covers the pure `src/lib` helpers (`*.test.ts` co-located); `cargo test` covers the git2 authorship/signature layer (temp repos built with git2, no git binary). UI is untested. See `docs/ROADMAP.md`. (Comment persistence is done - SQLite.)
+- **No i18n** - deferred. Tests: Vitest covers the pure `src/lib` helpers (`*.test.ts` co-located); `cargo test` covers the git2 authorship/signature layer (temp repos built with git2, no git binary). UI is untested. See `docs/ROADMAP.md`.
 
 ## Gates
 
@@ -29,75 +31,100 @@ pnpm test        # Vitest (pure lib helpers)
 pnpm build       # tsc && vite build  (catches issues the others miss)
 ```
 
-When Biome flags formatting: `pnpm exec biome check --write .` fixes most cases.
+When Biome flags formatting: `pnpm exec biome check --write .` fixes most cases. Rust changes additionally get `cargo test`, `cargo clippy --all-targets`, `cargo fmt --check`.
 
 ## File map
 
 ```
 src/
-├── App.tsx                       # top layout: sidebar | (header + content + comments)
+├── App.tsx                       # top layout: sidebar | (breadcrumbs + active view + AI/checks/comments panels)
+├── SplashScreen.tsx              # branded splash held until the initial load settles
 ├── sidebar/
-│   ├── AppSidebar.tsx            # frame: header / content / footer; 260 ↔ 64 collapse
-│   └── SidebarFooter.tsx         # Settings (placeholder dialog) + Theme toggle
+│   ├── AppSidebar.tsx            # frame: header / content / footer; expand ↔ collapse
+│   ├── SidebarFooter.tsx         # Settings dialog (General/Reading/AI tabs) + About + theme toggle
+│   ├── AboutDialog.tsx           # version display (the only one - see memory) + update notice
+│   └── AiSettingsSection.tsx     # AI tab: model download/import/selection
 ├── repos/
-│   ├── RepositorySwitcher.tsx    # dropdown over repoSources; ⌘1..N (loaded only); per-row delete; missing-folder warning
+│   ├── RepositorySwitcher.tsx    # dropdown over repoSources; ⌘1..N; per-row delete; missing/stale indicators
 │   ├── addRepo.ts                # pickAndAddRepoSource() - folder picker → addRepoSource()
 │   └── RepoConfigModal.tsx       # per-repo config view (legacy; kept for now)
+├── views/                        # one component per sidebar destination
+│   ├── OverviewView.tsx          # stats, AI overview summary, activity, spec-check findings
+│   ├── ChangesView.tsx           # filterable change list (per-row check badges) → ChangeViewer
+│   ├── SpecsView.tsx             # capability specs → SpecCapabilityViewer
+│   ├── SchemasView.tsx           # openspec/schemas/ YAML viewer
+│   ├── FolderView.tsx            # auto-discovered Library folders (adr/, playbooks/, ...)
+│   ├── FlowView.tsx / GraphView.tsx / TimelineView.tsx
+│   ├── RepoDocLayout.tsx / RepoDocList.tsx / Breadcrumbs.tsx / ErrorBoundary.tsx
 ├── specs/
-│   ├── ChangeViewer.tsx          # title row (with stats/comments buttons) + attribution + tabs + body
-│   ├── ChangesSidebar.tsx        # expanded list / collapsed avatar-initials mode
-│   ├── AttributionLine.tsx       # avatar(s) + "Created by X · edited by Y, 2d ago"
-│   ├── MarkdownView.tsx          # ReactMarkdown + selection + highlight rendering
+│   ├── ChangeViewer.tsx          # title row (checks badge, AI, stats, comments) + attribution + tabs + body
+│   ├── SpecCapabilityViewer.tsx  # canonical spec + per-change delta tabs
+│   ├── MarkdownView.tsx          # ReactMarkdown + comment highlights + check underlines + hover popovers
 │   ├── Minimap.tsx               # spine + slide-out TOC panel (HackMD-style)
-│   └── DocumentStatsModal.tsx    # words / chars / paragraphs / sentences / headings / read time
+│   ├── AttributionLine.tsx       # avatar(s) + "Created by X · edited by Y, 2d ago"
+│   ├── AiDocSummaryButton.tsx / AiSummaryPanel.tsx
+│   ├── SpecChecksBadge.tsx       # title-row toggle for the checks panel
+│   ├── SpecChecksPanel.tsx       # right panel: findings grouped by change, click = jump
+│   ├── specCheckJump.ts          # shared navigate-and-highlight for check findings
+│   ├── DocumentStatsTooltip.tsx  # words / read time / headings tooltip
+│   └── MermaidDiagram.tsx / MermaidLightbox.tsx   # lazy-loaded ```mermaid rendering
 ├── comments/
-│   ├── CommentsPanel.tsx         # right panel; unresolved/resolved tabs; quote-click jump
-│   ├── SelectionPopover.tsx      # floating "add comment" on text selection
-│   └── mockComments.ts           # seed comments (only one has a highlight wired)
-├── lib/
-│   ├── comments.ts               # AppComment + Highlight types
-│   ├── exampleLoader.ts          # async loadRepoFromPath(path) → Repo (calls Tauri load_repo)
-│   ├── documentSource.ts         # getCurrentSource(change, tab)
-│   ├── documentStats.ts          # computeDocumentStats(source)
-│   ├── extractHeadings.ts        # uses github-slugger to match rehype-slug
-│   ├── highlight.ts              # DOM-mutation <mark> wrapping; tracks occurrence index
-│   ├── tasksCompletion.ts        # counts `- [x]` outside fenced code blocks
-│   └── relativeTime.ts           # Intl.RelativeTimeFormat + absolute formatter
+│   ├── CommentsPanel.tsx         # right panel; scopes + resolved tabs; quote-click jump; md export
+│   └── SelectionPopover.tsx      # floating "add comment" on text selection
+├── search/SearchPalette.tsx      # ⌘K palette
+├── onboarding/TutorialDialog.tsx # first-launch tour (replayable from Settings)
+├── lib/                          # pure helpers, Vitest-covered; keep Tauri imports out
+│   ├── repoLoader.ts             # loadRepoFromPath(path) → Repo (calls Tauri load_repo)
+│   ├── repoCache.ts / db.ts      # SQLite cold-start cache + storage layer
+│   ├── schema.ts                 # OpenSpec schema parsing; artifact → document resolution
+│   ├── specChecks.ts             # lint engine (see Stack decisions)
+│   ├── specChecksConfig.ts       # check registry: ids, severities, messages, word lists
+│   ├── highlight.ts              # DOM-mutation <mark> wrapping; occurrence index; className per target
+│   ├── earsKeywords.ts           # EARS keyword rehype highlighter
+│   ├── aiSummary.ts / aiDocSummary.ts / aiSummaries.ts / ai.ts   # prompt builders + AI plumbing
+│   ├── extractHeadings.ts / documentSource.ts / documentStats.ts
+│   ├── tasksCompletion.ts / relativeTime.ts / markdownPreview.ts / stripDatePrefix.ts
+│   ├── changeFlow.ts / orphanDetection.ts / updateCheck.ts
+│   └── useCurrentDocument.ts / useMinDelay.ts / useRepoSyncWatcher.ts
 ├── store/
-│   ├── useAppStore.ts            # repoSources (persisted) + repos + add/remove/reload actions + UI state
-│   └── useCommentsStore.ts       # not persisted; seeds from mockComments
-└── (src-tauri/src/lib.rs)        # load_repo command: walk openspec/, per-file authorship via git2 (rename-following), return RepoPayload
+│   ├── useAppStore.ts            # sources + repos + settings + UI state (see Stack decisions)
+│   ├── useCommentsStore.ts       # comments, persisted via SQLite
+│   ├── useAiStore.ts             # AI generation state + summary caches
+│   └── bootstrap.ts              # hydrate from SQLite + write-through subscriptions
+src-tauri/src/
+├── lib.rs                        # load_repo / repo_signature / resolve_repo_root; single-pass authorship
+├── ai.rs                         # ai_* commands: model registry, llama.cpp + Ollama backends
+└── appimage.rs                   # Linux AppImage startup safeguards (Wayland preload re-exec)
 ```
 
 ## Authorship pipeline
 
-Authorship is derived at app start by the Rust `load_repo` command. For each project, when a `.git/` is found at the project root or its immediate parent (no further walk-up - see `find_git_root`), it walks history per tracked file with the `git2` crate (vendored libgit2, so users don't need git installed) - a hand-rolled `git log --follow` equivalent: revwalk from HEAD, mailmap-resolved author name/email (`%aN`/`%aE` semantics), `%aI`-shaped ISO dates, rename detection via `find_similar` - and emits per-file `DocAuthorship` plus a per-change rollup (`<archive/>?<slug>` → oldest/newest commit). The JS loader hydrates this into `Change.authorship`, `createdAt`, and `archivedAt`. **No `history.json` file is involved** - the git history *is* the source of truth.
+Authorship is derived at load time by the Rust `load_repo` command. When a `.git/` is found at the project root or its immediate parent (no further walk-up - see `find_git_root`), `collect_file_histories` walks history **once** for all tracked files: each commit is diffed against its parents with the diff restricted to the `openspec/` subtree, touched paths are attributed to the tracked file currently at that path, and renames are followed per file (first-parent rename detection when a tracked path appears as an add - this is what keeps archive moves attributed). Mailmap-resolved author name/email (`%aN`/`%aE` semantics), `%aI`-shaped ISO dates. Emits per-file `DocAuthorship` plus a per-change rollup (`<archive/>?<slug>` → oldest/newest commit). The JS loader hydrates this into `Change.authorship`, `createdAt`, and `archivedAt`. **No `history.json` file is involved** - the git history *is* the source of truth.
+
+**Do not reintroduce per-file history walks.** The previous implementation ran a `git log --follow` equivalent per file - O(files × commits) - and hung for 9+ minutes on a repo with 4.5k commits and 2.8k specs; the single pass loads the same repo in ~4s. `SPECLENS_BENCH_REPO=<path> cargo test --release bench_real_repo -- --ignored --nocapture` measures it.
 
 When `.git/` is absent, the command still returns a `RepoPayload` with file content; `authorship`, `createdAt`, and `archivedAt` come through as `null` and the AttributionLine renders blank.
 
 ## Non-obvious things
 
 - **Highlight blink scroll** (MarkdownView): `setScrollTarget(null)` is **inside** the `setTimeout` callback. Don't hoist it - if the state clears synchronously, React re-renders and `applyHighlights` strips the `<mark>` before its CSS animation paints.
+- **Check underlines ride the comment-highlight mechanism.** `HighlightTarget.className` styles a mark as a severity-colored wavy underline instead of a comment fill. Comments win key (`text|occurrence`) collisions; a transient anchor target is added for scroll targets matching no existing mark so a finding jump always has something to flash.
+- **Spec-check snippets are rendered text.** `SpecCheckResult.snippet` is the offending line with markdown syntax stripped (`toSnippet`), because `highlight.ts` matches the DOM's flattened text. Single `*emphasis*` is deliberately not stripped - such lines fall back to a plain jump.
 - **ChangeViewer scroll-reset effect:** the `useEffect` resetting `scrollTop` on `change` changes calls `useAppStore.getState().scrollTarget` and bails if a scroll target is pending. Otherwise it cancels the comment-jump smooth scroll.
-- **Repo switching:** `setSelectedRepoId` atomically resets `selectedChangeKey: null` + `activeTab: "proposal"`. App's existing effect then picks the first change of the new repo.
-- **Document ID format:** `<slug>/<tab>` (e.g. `add-search-bar/proposal`). **Not** scoped per-repo yet - if the same slug exists across multiple example repos, a comment's highlight applies in all of them. Extend `Highlight` with a `repoId` field when this becomes an issue.
+- **Repo switching:** `setSelectedRepoId` atomically resets `selectedChangeKey: null` + `activeTab: "proposal"`.
+- **Document ID formats:** `<slug>/<tab>` normally, `<slug>/<tab>/<file>` when a tab resolves to multiple files, and `spec:<cap>` / `spec:<cap>:<changeKey>` in the SpecCapabilityViewer. `findingDocumentId` in specChecks.ts mirrors the change-doc rule - keep them in sync with MarkdownView.
 - **rehype-sanitize runs between rehype-raw and rehype-slug** in MarkdownView. Order matters: slug ids and EARS keyword classes are added after sanitization so they survive; `language-*` code classes and GFM checkboxes are allowed by the GitHub-style default schema. Don't move plugins around without rechecking this.
-- **Repo `name` / `type` / `id` are derived from folder name** - `name = id = path's final segment`, `type = "local"`. To customize display names, add a field to `openspec/config.yaml` and read it in `payloadToRepo`.
-- **Missing-folder handling.** When `loadRepoFromPath` throws (folder gone, no `openspec/`, etc.), `reloadAllSources` marks that source `missing: true` instead of dropping it. The RepositorySwitcher renders it with `FolderOffIcon` + warning border, disables selection, and shows the close button always (instead of hover-only) so the user can remove it.
+- **Repo `name` / `type` are derived from folder name**; `id` is the full source path (unique across same-named folders). To customize display names, add a field to `openspec/config.yaml` and read it in `payloadToRepo`.
+- **Missing-folder handling.** When `loadRepoFromPath` throws (folder gone, no `openspec/`, etc.), `reloadAllSources` marks that source `missing: true` instead of dropping it. The RepositorySwitcher renders it with a warning and disables selection so the user can remove or relocate it.
 - **adr/ goes through rootFiles.** The schema's `adr` artifact has `generates: "../../../adr/*.md"`; `classifyGenerates` strips the `..` segments and matches against the repo-root file map. The loader populates rootFiles with `openspec/`-stripped keys (e.g. `adr/0001-...md`) so this pattern resolves.
-- **ChangesSidebar collapsed mode** renders 32×32 avatars with initials (`getInitials(change.name)`); active uses `primary.main`, archived uses 60% opacity.
 - **Minimap viewport indicator** is sized by visible *bars* (count of in-viewport headings), not by `scrollTop/scrollHeight` ratio. See the bar-position logic before "fixing" this - earlier attempts to use scroll-proportion were rejected.
-
-## Mock data
-
-- `src/comments/mockComments.ts` - 5 comments (3 unresolved / 2 resolved). One has a highlight bound to `add-search-bar/proposal` (Daniel Reis's "fuzzy matching" comment) - useful demo for comment-jump.
 
 ## Conventions
 
 - Tab indentation (Biome enforced).
-- Per-icon imports for `@mui/icons-material` (e.g. `import LockIcon from "@mui/icons-material/Lock"`) so tree-shaking works.
+- Per-icon imports for `@mui/icons-material` (e.g. `import LockIcon from "@mui/icons-material/Lock"`) so tree-shaking works. Icons v9 renamed some modules (`ErrorOutline` → `ErrorOutlined`) - check `node_modules/@mui/icons-material/` when an import fails.
 - `keyframes` from `@emotion/react` - `@mui/system` isn't a direct dependency.
 
 ## When in doubt
 
-Read `docs/ROADMAP.md` - every hardcoded value flagged as "should be configurable" plus the broader roadmap.
+Read `docs/ROADMAP.md` (hardcoded values flagged as "should be configurable" plus the broader roadmap) and `docs/design/checks-and-claims.md` (the Checks/Claims/Export direction and its tier policy for local-AI assist).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,8 @@ Reads OpenSpec projects from local folders at runtime via a Tauri command. Users
 - **Tauri `load_repo(path)` command** in `src-tauri/src/lib.rs` loads one project: walks its `openspec/` subtree, reads markdown + yaml, and (when a `.git/` exists at the project root or its immediate parent - see `find_git_root`) derives `DocAuthorship` per file via the `git2` crate (vendored libgit2 - no git binary needed). Authorship comes from **one history walk for all files** (`collect_file_histories`) - see "Authorship pipeline". The git-root walk is intentionally capped at one level up so that loading a folder from inside an unrelated git checkout (e.g. somewhere under `~`) doesn't pull authorship from that repo. JS calls the command once per source and catches per-source errors to mark `missing: true`. **Git is optional** - when absent, `Change.authorship`, `createdAt`, and `archivedAt` are `null` and the UI degrades gracefully.
 - **Per-repo cold-start cache.** Each `load_repo` response includes a `signature` (git: `HEAD-sha + scoped porcelain status` hash; non-git: hash of `openspec/` file mtimes). The fast Tauri command `repo_signature(path)` returns the signature alone (no file reads). On cold start, `reloadAllSources` fetches the signature first; if it matches the cached entry in SQLite (`repo_cache` table, keyed by path), the saved `Repo` is used as-is - no walking, no git log. Mismatch → full reload + cache overwrite. See `src/lib/repoCache.ts` (thin wrapper over `src/lib/db.ts`). Dates in cached entries get revived (JSON round-trip loses the `Date` type). `useRepoSyncWatcher` polls the selected repo's signature (15s + window focus) and only *marks* it stale - reload is always user-initiated.
 - **Local AI (`src-tauri/src/ai.rs`).** On-device summaries via llama.cpp (Metal) or an Ollama backend, exposed as `ai_*` commands. Nothing downloads or runs until the user fetches a model, so the no-network promise holds. Prompts are built on the JS side (`src/lib/aiSummary.ts`, `aiDocSummary.ts` - pure, unit-tested); Rust just receives the final string.
-- **Spec checks (deterministic lint).** `src/lib/specChecks.ts` is the engine (structural SL00x errors, consistency SL01x warnings, language SL02x checks); `src/lib/specChecksConfig.ts` is the registry - ids, severities, titles, message templates, and word lists all live there, the engine holds only detection logic. Both modules must stay pure (no Tauri imports) so the lint core can be extracted into a CLI later (see `docs/design/checks-and-claims.md`). Surfaced as a right-side results panel, list badges, and in-document wavy underlines with hover diagnostics. `settings.specChecks` (default on) gates all computation.
+- **Spec checks (deterministic lint, labelled Beta).** `src/lib/specChecks.ts` is the engine (structural SL00x errors, consistency SL01x warnings, language SL02x checks) covering active change deltas + canonical `specs/<cap>/spec.md`; `src/lib/specChecksConfig.ts` is the registry - ids, severities, titles, message templates, and word lists all live there, the engine holds only detection logic. Both modules must stay pure (no Tauri imports) so the lint core can be extracted into a CLI later (see `docs/design/checks-and-claims.md`). Surfaced as: a Checks navigation view (two-level tree, by change or by check), a drag-resizable right panel that scopes to the open change/spec and hides on non-checkable views, in-document wavy underlines with hover diagnostics, list badges, and a ChangeViewer banner for findings with no text anchor. **All UI reads results through `src/specs/useSpecChecks.ts` (`useSpecCheckResults`)** - never call `runSpecChecks` from a component directly, the hook owns the settings wiring (`specChecks`, default on; `specChecksIncludeArchived`, default off).
+- **One right panel at a time.** Comments, spec checks, and the AI summary are mutually exclusive: an arbiter effect in App.tsx closes the other two on any panel's closed→open transition (last opened wins). Panel open state stays where it always lived (App / useAppStore / useAiStore).
 - **`@tauri-apps/plugin-dialog`** powers the "Add repository" folder picker (capability `dialog:default`).
 - **No i18n** - deferred. Tests: Vitest covers the pure `src/lib` helpers (`*.test.ts` co-located); `cargo test` covers the git2 authorship/signature layer (temp repos built with git2, no git binary). UI is untested. See `docs/ROADMAP.md`.
 
@@ -51,6 +52,7 @@ src/
 ├── views/                        # one component per sidebar destination
 │   ├── OverviewView.tsx          # stats, AI overview summary, activity, spec-check findings
 │   ├── ChangesView.tsx           # filterable change list (per-row check badges) → ChangeViewer
+│   ├── ChecksView.tsx            # spec-check analysis: two-level tree, severity/text filters
 │   ├── SpecsView.tsx             # capability specs → SpecCapabilityViewer
 │   ├── SchemasView.tsx           # openspec/schemas/ YAML viewer
 │   ├── FolderView.tsx            # auto-discovered Library folders (adr/, playbooks/, ...)
@@ -63,9 +65,10 @@ src/
 │   ├── Minimap.tsx               # spine + slide-out TOC panel (HackMD-style)
 │   ├── AttributionLine.tsx       # avatar(s) + "Created by X · edited by Y, 2d ago"
 │   ├── AiDocSummaryButton.tsx / AiSummaryPanel.tsx
-│   ├── SpecChecksBadge.tsx       # title-row toggle for the checks panel
-│   ├── SpecChecksPanel.tsx       # right panel: findings grouped by change, click = jump
+│   ├── SpecChecksBadge.tsx       # title-row panel toggle + shared CheckSeverityCounts
+│   ├── SpecChecksPanel.tsx       # right panel: resizable, scoped to open change/spec
 │   ├── specCheckJump.ts          # shared navigate-and-highlight for check findings
+│   ├── useSpecChecks.ts          # useSpecCheckResults - the only component entry to the engine
 │   ├── DocumentStatsTooltip.tsx  # words / read time / headings tooltip
 │   └── MermaidDiagram.tsx / MermaidLightbox.tsx   # lazy-loaded ```mermaid rendering
 ├── comments/

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ SpecLens reads the OpenSpec convention (`proposal.md` / `tasks.md` / `specs/<cap
 - **Authorship** - when a project is a git repository, SpecLens derives per-document history (via an embedded git library - no git installation needed) to show who created and last edited each change. Without a repo it degrades gracefully.
 - **Comments** - select any text to attach a comment; highlights persist locally (SQLite) and can be exported as markdown, ready to paste into an LLM conversation.
 - **EARS keyword highlighting** - inline coloring for [EARS](https://alistairmavin.com/ears/) keywords, RFC 2119 modal verbs, and Gherkin steps (toggle in Settings).
+- **Spec checks (beta)** - deterministic, local-only linting of changes and specs: missing documents, malformed EARS/Gherkin blocks, empty or duplicated requirements, RFC 2119 misuse, ambiguous wording. Findings render as IDE-style underlines with hover diagnostics, plus a dedicated Checks view (groupable by change or check type), a scoped results panel, and severity badges across the app. No LLM involved; everything is explainable and reproducible. Toggle in Settings, with an opt-in for archived changes.
 - **Reader comforts** - minimap with table of contents, document stats and reading time, search palette, Mermaid diagram rendering, zoom, light/dark theme.
 - **Local AI summaries (optional)** - an on-device model summarizes the whole project and individual documents for reviewers, streamed into a side panel with links back to the specs. Five curated models downloaded on demand, any llama.cpp-compatible GGUF you import, or your local [Ollama](https://ollama.com) library. Inference never touches the network.
 
@@ -88,14 +89,14 @@ Tauri 2 (Rust) · React 19 + TypeScript + Vite · MUI + Emotion · Zustand with 
 ```
 src/
 ├── App.tsx        # top-level layout: sidebar | header + content + comments
-├── views/         # overview, changes, specs, schemas, folder, graph, flow, timeline
-├── specs/         # change viewer, markdown rendering, minimap, stats
+├── views/         # overview, changes, checks, specs, schemas, folder, graph, flow, timeline
+├── specs/         # change viewer, markdown rendering, minimap, stats, spec-check panel
 ├── comments/      # comments panel + selection-to-comment
 ├── repos/         # repository switcher + add-repository flow
 ├── sidebar/       # navigation, settings, theme toggle
 ├── search/        # search palette
 ├── store/         # Zustand stores + SQLite bootstrap
-└── lib/           # loaders, git-derived authorship, stats, highlighting
+└── lib/           # loaders, spec-check lint engine, stats, highlighting
 src-tauri/         # Rust shell: repo walking, git2 authorship, signatures, local AI
 ```
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -31,7 +31,7 @@ The plumbing is done (`AppSettings` in `useAppStore`, persisted as one kv blob -
 ## Features
 
 - [ ] **Spec validation (deterministic core, local-AI assist)** - deterministic first, local-LLM assist second, never silent; full design and tier policy in [docs/design/checks-and-claims.md](./design/checks-and-claims.md).
-  - [x] **Checks (Tier 0 lint engine)** - shipped: structural / consistency / language checks (`SL0xx` ids) in `src/lib/specChecks.ts` with a config registry, surfaced as a results panel, badges, in-document underlines with hover diagnostics, and an Overview section. `settings.specChecks`, on by default.
+  - [x] **Checks (Tier 0 lint engine, beta)** - shipped: structural / consistency / language checks (`SL0xx` ids) in `src/lib/specChecks.ts` with a config registry, over active deltas + canonical specs (archived opt-in). Surfaced as a Checks navigation view (tree, by change/by check), a scoped resizable results panel, in-document underlines with hover diagnostics, and badges. `settings.specChecks` on by default, labelled Beta.
   - [ ] **Claims (Tier 0 parsing)** - EARS parsing into structured claims, readiness gaps, approval state in SQLite
   - [ ] **Assist + Export (Tier 1)** - "Interpret with AI" via the local model with grammar-constrained output; JSON claim export
   - further out: formalize requirement claims and hand them to an SMT solver (Z3) for contradiction detection, as spec-check does

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -30,10 +30,10 @@ The plumbing is done (`AppSettings` in `useAppStore`, persisted as one kv blob -
 
 ## Features
 
-- [ ] **Spec validation without LLMs** - in the spirit of [spec-check](https://github.com/ohpauleez/spec-check): deterministic, read-only analysis of the loaded OpenSpec docs to surface errors and mistakes before implementation. Candidate checks, roughly in order of effort:
-  - structural: change folders missing `proposal.md` / `tasks.md`, spec deltas referencing capabilities that don't exist, malformed EARS/Gherkin blocks (`WHEN` without `THEN`, scenario without a requirement)
-  - consistency: requirements duplicated across capabilities, archived changes still referenced by active ones, task lists that don't match the delta they claim to implement
-  - language lint: RFC 2119 misuse (lowercase "shall", `SHOULD` + `MUST` in one clause), ambiguity flags ("fast", "appropriate", "etc.")
+- [ ] **Spec validation (deterministic core, local-AI assist)** - deterministic first, local-LLM assist second, never silent; full design and tier policy in [docs/design/checks-and-claims.md](./design/checks-and-claims.md).
+  - [x] **Checks (Tier 0 lint engine)** - shipped: structural / consistency / language checks (`SL0xx` ids) in `src/lib/specChecks.ts` with a config registry, surfaced as a results panel, badges, in-document underlines with hover diagnostics, and an Overview section. `settings.specChecks`, on by default.
+  - [ ] **Claims (Tier 0 parsing)** - EARS parsing into structured claims, readiness gaps, approval state in SQLite
+  - [ ] **Assist + Export (Tier 1)** - "Interpret with AI" via the local model with grammar-constrained output; JSON claim export
   - further out: formalize requirement claims and hand them to an SMT solver (Z3) for contradiction detection, as spec-check does
 - [ ] **Local AI: capability summaries + project Q&A** - enabled by default but fully on-device and inert until the user explicitly downloads a model (preserves the no-network promise). Phased:
   1. **Overview summaries** - a high-level AI-generated summary of the repo's capabilities on the Overview page, each linking to its spec. Generated per repo, cached in SQLite keyed by the existing repo `signature` (regenerates only when specs change). Internal link scheme routes to the Specs view.

--- a/docs/design/checks-and-claims.md
+++ b/docs/design/checks-and-claims.md
@@ -1,0 +1,201 @@
+# Design: Checks and Claims
+
+Status: **Feature 1 (Checks) is implemented** (`feature/spec-checks`); see the implementation notes in that section for where it deviates from or extends the sketch below. Features 2 (Claims) and 3 (Export) are not started.
+
+## Thesis
+
+Agents make producing code cheap, so verification of *intent* becomes the bottleneck. SpecLens sits exactly at the layer where intent is inspected before it becomes code. The long-term direction is:
+
+> Turn human-readable specifications into explicit, checkable claims - and eventually track the evidence that they hold.
+
+This document covers only the first slice of that: three features that are shippable with what the app already has, plus a revision of the "no LLM" stance on the current roadmap.
+
+1. **Checks** - deterministic spec linting (structural, consistency, language).
+2. **Claims** - parse EARS-shaped requirements into structured claims (trigger / preconditions / outcomes / invariants), show gaps, let the user approve the interpretation.
+3. **Export** - emit approved claims as stable JSON that a coding agent can consume.
+
+Explicitly out of scope for this slice (see "Deferred"): verification adapters, test/evidence tracking, SMT contradiction detection, CLI/MCP packaging.
+
+## Revised LLM policy
+
+The roadmap currently frames validation as "Spec validation without LLMs". That framing is half right: determinism should be the default, but it is a *preference ordering*, not a ban - especially now that the local AI stack (llama.cpp + Ollama via the `ai_*` commands) is implemented and preserves the no-network promise.
+
+New policy - **deterministic first, local LLM assist second, never silent**:
+
+- **Tier 0 (always on, no model required).** Everything that can be computed is computed: all lint checks, EARS grammar parsing, readiness gaps. These run for every user, produce the same result every time, and are fully explainable.
+- **Tier 1 (opt-in, local model required).** Where parsing fails - a requirement written in free prose - the user can invoke "Interpret with AI" on that requirement. The local model proposes a structured claim.
+- **Guardrails on Tier 1:**
+  - LLM output must validate against the same claim schema the parser emits. Use llama.cpp grammar-constrained sampling (GBNF) so the model *cannot* produce malformed output; Ollama backend falls back to JSON-schema validation + retry.
+  - Every claim carries `source: "parsed" | "inferred"`. Inferred claims are visually distinct and start `unreviewed`.
+  - An inferred claim is never exported as approved without an explicit human approval click. Wrong-but-confident formalization is the failure mode this exists to prevent.
+  - Per-action invocation only. No background LLM passes over the whole repo.
+
+Roadmap change if this doc is approved: retitle the feature to "Spec validation (deterministic core, local-AI assist)" and fold the tier language in. *(Done - see docs/ROADMAP.md.)*
+
+## Feature 1: Checks (spec linting)
+
+Deterministic analysis of a loaded repo, in the spirit of spec-check. Pure TypeScript in `src/lib/specChecks.ts` (+ co-located Vitest tests), operating on the already-loaded `Repo` object - no new Rust needed.
+
+### Check categories
+
+Each check has a stable id (`SL###`), a severity (`error` / `warning` / `info`), a message, and a location (change slug + tab + heading anchor where possible, so results can deep-link via the existing `scrollTarget` mechanism).
+
+**Structural (errors)**
+- `SL001` change folder missing `proposal.md`
+- `SL002` change folder missing `tasks.md`
+- `SL003` spec delta references a capability that does not exist
+- `SL004` malformed EARS/Gherkin block: `WHEN` without `THEN`, `GIVEN` without `THEN`, scenario without an owning requirement
+- `SL005` requirement heading with an empty body
+
+**Consistency (warnings)**
+- `SL010` near-duplicate requirement text across capabilities
+- `SL011` archived change still referenced by an active change
+- `SL012` task list does not mention any capability its spec delta touches
+- `SL013` tasks all complete but change not archived (and the inverse)
+
+**Language (warnings/info)**
+- `SL020` RFC 2119 misuse: lowercase "shall"/"must" in normative position
+- `SL021` conflicting modality in one clause (`SHOULD` + `MUST`)
+- `SL022` ambiguity flags: "fast", "quickly", "appropriate", "reasonable", "etc.", "as needed" (word list in one exported const, easy to extend)
+- `SL023` unbounded quantity: "some", "several", "many" in a normative sentence
+
+### Surfacing
+
+- Per-change: a badge on the change title row (count by max severity), opening a results list; each row deep-links to the offending heading.
+- Per-repo: aggregate count in the changes sidebar header.
+- A setting to disable checks entirely (`settings.specChecks: boolean`), following the existing `AppSettings` pattern.
+
+Checks are recomputed when a repo (re)loads - same lifecycle as the repo cache, no persistence needed.
+
+### Implementation notes (shipped)
+
+Where the implementation settled relative to the sketch above:
+
+- **Engine + config split.** Detection logic lives in `src/lib/specChecks.ts`; everything user-facing or tunable - ids, severities, titles, message templates, the SL022/SL023 word lists - lives in the `src/lib/specChecksConfig.ts` registry. Changing a severity or message is a one-line config edit. Both modules are pure (no Tauri imports), preserving the CLI extraction path.
+- **Surfacing went further than the badge sketch:** an IDE-style right panel (like the comments panel) with findings grouped by change, per-row severity counts in the changes list, severity-colored wavy underlines on the offending text in rendered documents, hover diagnostics on the underlines, and a findings section + stat card on the Overview. Clicking a finding anywhere navigates and blink-highlights the offending text via the existing scrollTarget mechanism (`jumpToFinding`).
+- **Scoping decisions:** archived changes are skipped except where the archive state is the point (SL011 reference targets, SL013 inverse), so history doesn't drown the signal. SL003 tolerates deltas that introduce a capability via an ADDED section. Language checks (SL02x) run on spec deltas only, where prose is normative.
+- **Findings carry a `snippet`** - the offending line as it renders (markdown syntax stripped) - so the highlight engine can locate it in the DOM.
+- `settings.specChecks` defaults to **on**.
+
+## Feature 2: Claims (structured requirements)
+
+### The claim model
+
+```ts
+type Modality = "MUST" | "MUST_NOT" | "SHOULD" | "SHOULD_NOT" | "MAY";
+
+interface RequirementClaim {
+	/** hash(repoId, capability, requirement heading text) - stable across reorders */
+	id: string;
+	source: "parsed" | "inferred";
+	/** approval invalidates automatically when the requirement text hash changes */
+	review: "unreviewed" | "approved" | "stale";
+	trigger: string | null;          // WHEN ...
+	preconditions: string[];         // IF / AND / GIVEN ...
+	outcomes: { modality: Modality; text: string }[];  // THEN ... MUST ...
+	invariants: string[];            // "... MUST remain unchanged" outcomes
+	gaps: ReadinessGap[];
+	requirementText: string;         // original prose, verbatim
+	textHash: string;
+}
+```
+
+### Tier 0 parsing
+
+A small recursive-descent parser over the requirement/scenario blocks the loader already extracts. Grammar is deliberately strict: uppercase keywords (`WHEN` / `WHILE` / `IF` / `GIVEN` / `AND` / `THEN` + RFC 2119 modals), one clause per line or sentence. This reuses the keyword set in `earsKeywords.ts` (currently highlight-only) - extract the list into a shared module.
+
+Requirements that do not parse are not errors. They surface as "unstructured" with the gap list explaining what is missing. The strictness is the point: SpecLens rewards specs written in checkable form.
+
+### Readiness gaps
+
+Computed per claim (parsed or not):
+
+- no trigger identified
+- no measurable bound on a quality adverb ("quickly", "efficiently")
+- no failure / rejection behaviour specified
+- quantifier unclear (one? every? at most one?)
+- no statement about what must remain unchanged
+- concurrent/repeated-invocation behaviour unspecified (heuristic: trigger present, no `WHILE` clause)
+
+Rendered as the checklist from the review discussion:
+
+```text
+Formalization readiness: 4/6
+✓ Trigger identified
+✓ Required outcome identified
+✗ "quickly" has no measurable bound
+✗ Failure behaviour unspecified
+```
+
+### Tier 1 assist
+
+For unstructured requirements, an "Interpret with AI" action sends the requirement text (plus its capability heading for context) to the local model with a GBNF grammar for the claim schema. The proposal renders in the same claim UI, marked *inferred*, diffable against the prose, with Approve / Discard. No batch mode in v1.
+
+### Approval persistence
+
+Approvals are review state, not content - they live in SpecLens's SQLite (new `claim_reviews` table: claim id, text hash, status, timestamp), following the comments pattern. If the requirement text changes on a later load, the stored hash mismatches and the claim shows `stale`.
+
+Writing claims back into the repo as files (so they version with the spec) is deliberately deferred - it would be SpecLens's first write path into user files and deserves its own decision.
+
+### UI
+
+A "Claims" view per change, sibling to the existing tabs, listing each requirement with its parse result, readiness checklist, and approval state. Per-capability rollup ("7 requirements: 4 parsed, 1 approved, 2 unstructured") on the spec view. Exact layout to be prototyped; not load-bearing for this review.
+
+## Feature 3: Export
+
+"Export claims" produces one JSON file per repo (or per change - open question):
+
+```json
+{
+	"speclensClaims": 1,
+	"repo": "payments-service",
+	"generatedFrom": { "signature": "…" },
+	"claims": [
+		{
+			"id": "a41f…",
+			"capability": "withdrawals",
+			"requirement": "Reject withdrawals exceeding balance",
+			"source": "parsed",
+			"review": "approved",
+			"trigger": "a withdrawal is requested",
+			"preconditions": ["withdrawal_amount > account_balance"],
+			"outcomes": [{ "modality": "MUST", "text": "the withdrawal is rejected" }],
+			"invariants": ["account balance remains unchanged"],
+			"gaps": []
+		}
+	]
+}
+```
+
+- Schema versioned via the top-level integer; additive changes only within a version.
+- Unreviewed and inferred claims are included but carry their status - consumers decide what to trust. Approved claims are the contract.
+- v1 export is a save-file dialog from the GUI (plus copy-to-clipboard). This is the thinnest entry into the agent loop: a human exports, an agent reads the file alongside the spec.
+
+### The CLI question (deferred, but named)
+
+The full agent loop (agent asks "which claims am I violating?" in CI) wants a CLI or MCP server, which means extracting the loader + checks + parser out of the app. That is an architecture fork: today the parsing pipeline is TypeScript inside the Tauri frontend. Options when we get there: publish the pure `src/lib` core as an npm package with a thin CLI, or port to a Rust crate shared with `src-tauri`. No decision needed now - but avoid adding Tauri imports to the new `src/lib` modules so the extraction stays possible. (`specChecks.ts`, the claim parser, and the export serializer must stay pure.)
+
+## Phasing
+
+1. **Checks** - lint engine + tests, badge + results list, setting. No LLM, no persistence. Smallest slice, ships alone.
+2. **Claims (Tier 0)** - claim model, EARS parser + tests, readiness gaps, Claims view, approval state in SQLite.
+3. **Assist + Export (Tier 1)** - "Interpret with AI" via the existing `ai_*` commands with grammar-constrained output, then JSON export.
+
+Each phase is independently useful; stop-anywhere is fine.
+
+## Deferred / out of scope
+
+- **Verification adapters** (generating property tests, SMT queries, temporal models) - company-sized surface; backend-neutrality multiplies the integration cost.
+- **Evidence tracking** (specified / implemented / tested / verified per requirement) - the most valuable long-term piece, but it needs stable requirement ids *in the spec files* and a convention for tests to reference them. Ecosystem work; revisit after Claims proves the id scheme.
+- **SMT contradiction detection** - keep on the roadmap as "further out". Honest expectation: real specs contain few machine-detectable contradictions; readiness gaps will fire daily, Z3 twice a year.
+- **Writing claims into the repo** - see approval persistence above.
+- **LLM-suggested ambiguity terms (SL022)** - an opt-in Tier 1 action where the local model reviews requirement prose and proposes *additions to the word list*; the user accepts or discards each, and accepted terms persist as a settings-layer extension of the base list in `specChecksConfig.ts`. The scan itself never calls the model, so checks stay deterministic and reproducible. Belongs with the Phase 3 assist work.
+- **Prior art to study before Phase 2 design hardens:** NASA FRET (EARS-like requirements compiled to temporal logic with human-reviewable semantics), classic requirements-traceability matrices.
+
+## Open questions for review
+
+1. Claims view placement: a new tab per change vs. a panel on the spec view vs. both?
+2. Export granularity: per repo, per change, or selectable?
+3. ~~Should `SL0xx` check ids be user-visible (greppable, suppressible later) or internal?~~ **Answered in v1: user-visible** - shown in the panel rows, hover diagnostics, and Overview list.
+4. ~~Ambiguity word list (`SL022`): hardcode v1, or make it a setting from day one?~~ **Answered in v1: hardcoded** exported const in `specChecksConfig.ts`; a user-editable settings layer is deferred (see the LLM-suggested-terms item).
+5. Is `claim_reviews` in app SQLite acceptable for now, knowing reviews don't travel with the repo?

--- a/docs/design/checks-and-claims.md
+++ b/docs/design/checks-and-claims.md
@@ -72,10 +72,10 @@ Checks are recomputed when a repo (re)loads - same lifecycle as the repo cache, 
 Where the implementation settled relative to the sketch above:
 
 - **Engine + config split.** Detection logic lives in `src/lib/specChecks.ts`; everything user-facing or tunable - ids, severities, titles, message templates, the SL022/SL023 word lists - lives in the `src/lib/specChecksConfig.ts` registry. Changing a severity or message is a one-line config edit. Both modules are pure (no Tauri imports), preserving the CLI extraction path.
-- **Surfacing went further than the badge sketch:** an IDE-style right panel (like the comments panel) with findings grouped by change, per-row severity counts in the changes list, severity-colored wavy underlines on the offending text in rendered documents, hover diagnostics on the underlines, and a findings section + stat card on the Overview. Clicking a finding anywhere navigates and blink-highlights the offending text via the existing scrollTarget mechanism (`jumpToFinding`).
+- **Surfacing went further than the badge sketch:** a dedicated Checks navigation view (two-level tree groupable by change or by check id, severity/text filters, collapsed by default), an IDE-style right panel (drag-resizable, scoped to the open change/spec, hidden on non-checkable views), per-row severity counts in the changes and specs listings, severity-colored wavy underlines with hover diagnostics in rendered documents, a ChangeViewer banner for findings with no text anchor, and a stat card on the Overview. Clicking a finding anywhere navigates and blink-highlights the offending text via the existing scrollTarget mechanism (`jumpToFinding`). Only one right panel (comments / checks / AI) is open at a time.
 - **Scoping decisions:** archived changes are skipped except where the archive state is the point (SL011 reference targets, SL013 inverse), so history doesn't drown the signal. SL003 tolerates deltas that introduce a capability via an ADDED section. Language checks (SL02x) run on spec deltas only, where prose is normative.
 - **Findings carry a `snippet`** - the offending line as it renders (markdown syntax stripped) - so the highlight engine can locate it in the DOM.
-- `settings.specChecks` defaults to **on**.
+- `settings.specChecks` defaults to **on**, labelled **Beta** in Settings; `settings.specChecksIncludeArchived` (off by default) opts archived changes into the full check set. All UI surfaces read results through the `useSpecCheckResults` hook.
 
 ## Feature 2: Claims (structured requirements)
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -634,6 +634,24 @@ mod tests {
             .unwrap()
     }
 
+    /// Temporary benchmark against a real repo. Run with:
+    /// SPECLENS_BENCH_REPO=/path cargo test --release bench_real_repo -- --ignored --nocapture
+    #[test]
+    #[ignore]
+    fn bench_real_repo() {
+        let Ok(path) = std::env::var("SPECLENS_BENCH_REPO") else {
+            return;
+        };
+        let start = std::time::Instant::now();
+        let payload = load_project("bench", Path::new(&path)).unwrap();
+        println!(
+            "load_project: {:?} ({} files, {} authorship entries)",
+            start.elapsed(),
+            payload.files.len(),
+            payload.authorship.len()
+        );
+    }
+
     #[test]
     fn follows_file_across_rename() {
         let tmp = tempfile::tempdir().unwrap();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -120,29 +120,40 @@ fn load_project(id: &str, project_root: &Path) -> Result<RepoPayload, String> {
                 .strip_prefix(git_root)
                 .map_err(|e| e.to_string())?;
             let project_rel_str = path_to_forward_slash(project_rel);
-            // For each tracked file, derive authorship across renames
-            // (the libgit2 equivalent of `git log --follow`).
+            // Derive per-file authorship across renames with ONE pass over
+            // history (see collect_file_histories) instead of a revwalk per
+            // file - the per-file variant was O(files x commits) and took
+            // minutes-to-hours on large repos.
+            let tracked: HashMap<String, String> = files
+                .keys()
+                .map(|rel| {
+                    let git_path = if project_rel_str.is_empty() {
+                        rel.clone()
+                    } else {
+                        format!("{}/{}", project_rel_str, rel)
+                    };
+                    (git_path, rel.clone())
+                })
+                .collect();
+            let pathspec = if project_rel_str.is_empty() {
+                "openspec".to_string()
+            } else {
+                format!("{}/openspec", project_rel_str)
+            };
+            let histories = collect_file_histories(&repo, mailmap.as_ref(), &tracked, &pathspec)
+                .unwrap_or_default();
             let mut commits_by_change: HashMap<String, Vec<CommitInfo>> = HashMap::new();
-            for rel in files.keys() {
-                let git_path = if project_rel_str.is_empty() {
-                    rel.clone()
-                } else {
-                    format!("{}/{}", project_rel_str, rel)
-                };
-                let commits = match git_log_follow(&repo, mailmap.as_ref(), &git_path) {
-                    Ok(c) => c,
-                    Err(_) => continue,
-                };
+            for (rel, commits) in histories {
                 if commits.is_empty() {
                     continue;
                 }
-                if let Some(change_key) = change_key_for(rel) {
+                if let Some(change_key) = change_key_for(&rel) {
                     commits_by_change
                         .entry(change_key)
                         .or_default()
                         .extend(commits.iter().cloned());
                 }
-                authorship.insert(rel.clone(), rollup(&commits));
+                authorship.insert(rel, rollup(&commits));
             }
             for (key, commits) in commits_by_change {
                 change_rollups.insert(key, rollup(&commits));
@@ -361,26 +372,6 @@ fn entry_sig(tree: &git2::Tree, path: &Path) -> Option<(git2::Oid, i32)> {
     tree.get_path(path).ok().map(|e| (e.id(), e.filemode()))
 }
 
-/// When `path` was added by `commit` (absent from every parent), run rename
-/// detection against the first parent and return the old path if the "add"
-/// was really a rename. This is what lets us keep following the file.
-fn find_rename_source(repo: &Repository, commit: &git2::Commit, path: &Path) -> Option<PathBuf> {
-    let parent_tree = commit.parent(0).ok()?.tree().ok()?;
-    let tree = commit.tree().ok()?;
-    let mut diff = repo
-        .diff_tree_to_tree(Some(&parent_tree), Some(&tree), None)
-        .ok()?;
-    let mut opts = git2::DiffFindOptions::new();
-    opts.renames(true);
-    diff.find_similar(Some(&mut opts)).ok()?;
-    for delta in diff.deltas() {
-        if delta.status() == git2::Delta::Renamed && delta.new_file().path() == Some(path) {
-            return delta.old_file().path().map(|p| p.to_path_buf());
-        }
-    }
-    None
-}
-
 fn commit_info(mailmap: Option<&Mailmap>, commit: &git2::Commit) -> CommitInfo {
     // %aN/%aE semantics: resolve the author through the repo's mailmap when
     // one exists; otherwise this behaves like plain %an/%ae.
@@ -436,38 +427,65 @@ fn civil_from_days(z: i64) -> (i64, u32, u32) {
     (if m <= 2 { y + 1 } else { y }, m, d)
 }
 
-/// The libgit2 equivalent of
-/// `git log --follow --format=%H%x09%aN%x09%aE%x09%aI -- <file_path>`:
-/// walks history from HEAD newest-first (commit-time order, git log's
-/// default), records every commit where the tracked path's blob differs from
-/// its parents', and when the file first appears as an add, uses rename
-/// detection to discover the old path and keeps following it.
+/// Single-pass authorship for every tracked file: the libgit2 equivalent of
+/// running `git log --follow --format=%H%x09%aN%x09%aE%x09%aI -- <path>` for
+/// each file, but with ONE revwalk over history instead of one per file.
+/// Each commit is diffed against its parents with the diff restricted to
+/// `pathspec` (the project's openspec/ subtree), and every touched path is
+/// attributed to the tracked file currently at that path. The old per-file
+/// walk was O(files x commits) and took minutes-to-hours on repos with
+/// thousands of commits and thousands of specs; this is O(commits) with
+/// cheap adjacent-tree diffs.
 ///
-/// Known divergences from `git log --follow`:
+/// Per-path semantics match the old walk:
+/// - A commit counts for a path when the path is TREESAME to no parent
+///   (for merges: changed against every parent - the intersection of the
+///   per-parent diffs).
+/// - When a tracked path appears as an add (absent from every parent),
+///   rename detection runs against the first parent and the old path is
+///   followed into older history.
+/// - Root commits count for every tracked path present in their tree.
+///
+/// Known divergences from `git log --follow` (mostly unchanged from the
+/// per-file implementation):
 /// - History simplification: when a merge is TREESAME to one parent, git
-///   silently follows only that parent and prunes the other side entirely.
-///   We walk all parents (skipping merge commits that are TREESAME to any
-///   parent), so commits whose changes were later discarded by a merge can
-///   still be reported.
+///   follows only that parent and prunes the other side. We record a commit
+///   whenever the path changed against every parent, so commits whose
+///   changes were later discarded by a merge can still be reported.
 /// - Rename detection runs against the first parent only, and only when the
 ///   file is absent from every parent.
+/// - Rename detection now happens inside the pathspec-limited diff, so a
+///   rename whose old path lies outside the openspec/ subtree is seen as a
+///   plain add (the per-file walk diffed the whole tree). Moves within
+///   openspec/ - e.g. archiving a change - are followed as before.
 /// - If a file was deleted and later re-added, we keep matching the same
 ///   path into older history instead of restarting follow at the re-add.
-fn git_log_follow(
+fn collect_file_histories(
     repo: &Repository,
     mailmap: Option<&Mailmap>,
-    file_path: &str,
-) -> Result<Vec<CommitInfo>, String> {
+    tracked: &HashMap<String, String>,
+    pathspec: &str,
+) -> Result<HashMap<String, Vec<CommitInfo>>, String> {
+    let mut histories: HashMap<String, Vec<CommitInfo>> = HashMap::new();
+    if tracked.is_empty() {
+        return Ok(histories);
+    }
+    // Where each tracked file lives at the point in history the walk has
+    // reached; rewritten as renames are discovered walking backward.
+    let mut current: HashMap<PathBuf, String> = tracked
+        .iter()
+        .map(|(git_path, rel)| (PathBuf::from(git_path), rel.clone()))
+        .collect();
+
     let mut revwalk = repo.revwalk().map_err(|e| e.to_string())?;
     revwalk
         .set_sorting(git2::Sort::TIME)
         .map_err(|e| e.to_string())?;
     if revwalk.push_head().is_err() {
         // Unborn HEAD (no commits yet): no history to report.
-        return Ok(Vec::new());
+        return Ok(histories);
     }
-    let mut current_path = PathBuf::from(file_path);
-    let mut commits: Vec<CommitInfo> = Vec::new();
+
     for oid in revwalk {
         let oid = match oid {
             Ok(o) => o,
@@ -481,33 +499,108 @@ fn git_log_follow(
             Ok(t) => t,
             Err(_) => continue,
         };
-        let cur = entry_sig(&tree, &current_path);
-        let parent_sigs: Vec<Option<(git2::Oid, i32)>> = commit
-            .parents()
-            .map(|p| p.tree().ok().and_then(|t| entry_sig(&t, &current_path)))
-            .collect();
-        if parent_sigs.is_empty() {
-            // Root commit: only relevant if it introduced the file.
-            if cur.is_none() {
-                continue;
+        let parent_trees: Vec<git2::Tree> =
+            commit.parents().filter_map(|p| p.tree().ok()).collect();
+
+        if parent_trees.is_empty() {
+            // Root commit: introduces every tracked path present in its tree.
+            for (path, rel) in &current {
+                if entry_sig(&tree, path).is_some() {
+                    histories
+                        .entry(rel.clone())
+                        .or_default()
+                        .push(commit_info(mailmap, &commit));
+                }
             }
-        } else if parent_sigs.contains(&cur) {
-            // TREESAME to at least one parent: the commit didn't touch the
-            // tracked path (or, for a merge, simply took one side's version).
             continue;
         }
-        commits.push(commit_info(mailmap, &commit));
-        // File added in this commit (absent from every parent): check
-        // whether the add was really a rename and keep following.
-        if cur.is_some() && !parent_sigs.is_empty() && parent_sigs.iter().all(|p| p.is_none()) {
-            if let Some(old) = find_rename_source(repo, &commit, &current_path) {
-                current_path = old;
+
+        // Tracked paths touched against EVERY parent (path -> added flag).
+        let mut touched: Option<HashMap<PathBuf, bool>> = None;
+        let mut first_diff: Option<git2::Diff> = None;
+        for (i, parent_tree) in parent_trees.iter().enumerate() {
+            let mut opts = git2::DiffOptions::new();
+            opts.pathspec(pathspec);
+            let diff = match repo.diff_tree_to_tree(Some(parent_tree), Some(&tree), Some(&mut opts))
+            {
+                Ok(d) => d,
+                Err(_) => continue,
+            };
+            let mut this_parent: HashMap<PathBuf, bool> = HashMap::new();
+            for delta in diff.deltas() {
+                let added = delta.status() == git2::Delta::Added;
+                if let Some(p) = delta.new_file().path() {
+                    if current.contains_key(p) {
+                        this_parent.insert(p.to_path_buf(), added);
+                    }
+                }
+                if let Some(p) = delta.old_file().path() {
+                    if current.contains_key(p) {
+                        this_parent.entry(p.to_path_buf()).or_insert(false);
+                    }
+                }
+            }
+            touched = Some(match touched {
+                None => this_parent,
+                // Merge: keep only paths changed against every parent seen
+                // so far; "added" holds only if added against all of them.
+                Some(prev) => prev
+                    .into_iter()
+                    .filter_map(|(p, added)| this_parent.get(&p).map(|a| (p, added && *a)))
+                    .collect(),
+            });
+            if i == 0 {
+                first_diff = Some(diff);
+            }
+            if touched.as_ref().is_some_and(|t| t.is_empty()) {
+                break;
+            }
+        }
+        let touched = touched.unwrap_or_default();
+        if touched.is_empty() {
+            continue;
+        }
+
+        let info = commit_info(mailmap, &commit);
+        for path in touched.keys() {
+            if let Some(rel) = current.get(path) {
+                histories.entry(rel.clone()).or_default().push(info.clone());
+            }
+        }
+
+        // Rename following for paths added against every parent.
+        let adds: Vec<PathBuf> = touched
+            .iter()
+            .filter(|(_, &added)| added)
+            .map(|(p, _)| p.clone())
+            .collect();
+        if adds.is_empty() {
+            continue;
+        }
+        let Some(mut diff) = first_diff else { continue };
+        let mut find_opts = git2::DiffFindOptions::new();
+        find_opts.renames(true);
+        if diff.find_similar(Some(&mut find_opts)).is_err() {
+            continue;
+        }
+        for delta in diff.deltas() {
+            if delta.status() != git2::Delta::Renamed {
+                continue;
+            }
+            let (Some(new_path), Some(old_path)) =
+                (delta.new_file().path(), delta.old_file().path())
+            else {
+                continue;
+            };
+            if adds.iter().any(|a| a == new_path) {
+                if let Some(rel) = current.remove(new_path) {
+                    current.insert(old_path.to_path_buf(), rel);
+                }
             }
         }
     }
-    Ok(commits)
+    Ok(histories)
 }
-
 /// `commits` is newest-first (git log default). Oldest = last element.
 fn rollup(commits: &[CommitInfo]) -> DocAuthor {
     let mut sorted = commits.to_vec();
@@ -678,8 +771,11 @@ mod tests {
         );
 
         let mailmap = repo.mailmap().ok();
-        let commits =
-            git_log_follow(&repo, mailmap.as_ref(), "openspec/changes/bar/proposal.md").unwrap();
+        let rel = "openspec/changes/bar/proposal.md";
+        let tracked = HashMap::from([(rel.to_string(), rel.to_string())]);
+        let histories =
+            collect_file_histories(&repo, mailmap.as_ref(), &tracked, "openspec").unwrap();
+        let commits = &histories[rel];
         assert_eq!(commits.len(), 2, "rename + original add");
         // Newest-first, like `git log`.
         assert_eq!(commits[0].name, "Bob");
@@ -687,10 +783,70 @@ mod tests {
         assert_eq!(commits[1].email, "alice@example.com");
 
         // And the rollup attributes creation to the pre-rename author.
-        let doc = rollup(&commits);
+        let doc = rollup(commits);
         assert_eq!(doc.created_by.name, "Alice");
         assert_eq!(doc.last_edited_by.name, "Bob");
         assert_eq!(doc.edit_count, 2);
+    }
+
+    #[test]
+    fn single_walk_attributes_commits_per_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let repo = Repository::init(tmp.path()).unwrap();
+        let a = "openspec/changes/a/proposal.md";
+        let b = "openspec/changes/b/proposal.md";
+        commit_file(
+            &repo,
+            a,
+            "a v1",
+            "Alice",
+            "alice@example.com",
+            Time::new(1_700_000_000, 0),
+            "add a",
+        );
+        commit_file(
+            &repo,
+            b,
+            "b v1",
+            "Bob",
+            "bob@example.com",
+            Time::new(1_700_100_000, 0),
+            "add b",
+        );
+        // A commit outside openspec/ must not be attributed to either file.
+        commit_file(
+            &repo,
+            "src/main.rs",
+            "fn main() {}",
+            "Carol",
+            "carol@example.com",
+            Time::new(1_700_150_000, 0),
+            "unrelated",
+        );
+        commit_file(
+            &repo,
+            a,
+            "a v2",
+            "Carol",
+            "carol@example.com",
+            Time::new(1_700_200_000, 0),
+            "edit a",
+        );
+
+        let tracked = HashMap::from([
+            (a.to_string(), a.to_string()),
+            (b.to_string(), b.to_string()),
+        ]);
+        let histories = collect_file_histories(&repo, None, &tracked, "openspec").unwrap();
+
+        let a_commits = &histories[a];
+        assert_eq!(a_commits.len(), 2, "add + edit");
+        assert_eq!(a_commits[0].name, "Carol"); // newest-first
+        assert_eq!(a_commits[1].name, "Alice");
+
+        let b_commits = &histories[b];
+        assert_eq!(b_commits.len(), 1);
+        assert_eq!(b_commits[0].name, "Bob");
     }
 
     #[test]
@@ -726,7 +882,10 @@ mod tests {
             Time::new(1_000_000_000, 90),
             "add",
         );
-        let commits = git_log_follow(&repo, None, "openspec/changes/x/proposal.md").unwrap();
+        let rel = "openspec/changes/x/proposal.md";
+        let tracked = HashMap::from([(rel.to_string(), rel.to_string())]);
+        let histories = collect_file_histories(&repo, None, &tracked, "openspec").unwrap();
+        let commits = &histories[rel];
         assert_eq!(commits.len(), 1);
         assert_eq!(commits[0].iso_date, "2001-09-09T03:16:40+01:30");
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,7 +20,7 @@ import {
 } from "@mui/material";
 import { getVersion, setTheme } from "@tauri-apps/api/app";
 import { openUrl } from "@tauri-apps/plugin-opener";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { CommentsPanel } from "./comments/CommentsPanel";
 import { useDocumentOrphans } from "./lib/orphanDetection";
 import {
@@ -50,6 +50,7 @@ import { useCommentsStore } from "./store/useCommentsStore";
 import { createAppTheme } from "./theme/theme";
 import { Breadcrumbs } from "./views/Breadcrumbs";
 import { ChangesView } from "./views/ChangesView";
+import { ChecksView } from "./views/ChecksView";
 import { ErrorBoundary } from "./views/ErrorBoundary";
 import { FlowView } from "./views/FlowView";
 import { FolderView } from "./views/FolderView";
@@ -290,6 +291,41 @@ function App() {
 	const [commentsOpen, setCommentsOpen] = useState(false);
 	const [commentsPinned, setCommentsPinned] = useState(false);
 	const [searchOpen, setSearchOpen] = useState(false);
+
+	// Only one right panel (comments / spec checks / AI summary) may be open
+	// at a time - side-by-side stacking eats the document area. Whichever
+	// opened last wins: the effect detects the false→true transition and
+	// closes the other two. Their own open state lives where it always did
+	// (App, useAppStore, useAiStore); this is just the arbiter.
+	const checksPanelOpen = useAppStore((s) => s.specChecksPanelOpen);
+	const setSpecChecksPanelOpen = useAppStore((s) => s.setSpecChecksPanelOpen);
+	const aiPanelOpen = useAiStore((s) => s.docSummary.open);
+	const closeDocSummaryPanel = useAiStore((s) => s.closeDocSummaryPanel);
+	const prevPanels = useRef({ comments: false, checks: false, ai: false });
+	useEffect(() => {
+		const prev = prevPanels.current;
+		if (commentsOpen && !prev.comments) {
+			setSpecChecksPanelOpen(false);
+			closeDocSummaryPanel();
+		} else if (checksPanelOpen && !prev.checks) {
+			setCommentsOpen(false);
+			closeDocSummaryPanel();
+		} else if (aiPanelOpen && !prev.ai) {
+			setCommentsOpen(false);
+			setSpecChecksPanelOpen(false);
+		}
+		prevPanels.current = {
+			comments: commentsOpen,
+			checks: checksPanelOpen,
+			ai: aiPanelOpen,
+		};
+	}, [
+		commentsOpen,
+		checksPanelOpen,
+		aiPanelOpen,
+		setSpecChecksPanelOpen,
+		closeDocSummaryPanel,
+	]);
 
 	const hasActiveDocument =
 		!!activeChange ||
@@ -555,6 +591,8 @@ function App() {
 									<SpecsView repo={activeRepo} {...sharedDetailProps} />
 								) : view === "changes" ? (
 									<ChangesView repo={activeRepo} {...sharedDetailProps} />
+								) : view === "checks" ? (
+									<ChecksView repo={activeRepo} />
 								) : view === "schemas" ? (
 									<SchemasView repo={activeRepo} />
 								) : view === "folder" ? (

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -37,6 +37,7 @@ import { SplashScreen } from "./SplashScreen";
 import { SearchPalette } from "./search/SearchPalette";
 import { AppSidebar } from "./sidebar/AppSidebar";
 import { AiSummaryPanel } from "./specs/AiSummaryPanel";
+import { SpecChecksPanel } from "./specs/SpecChecksPanel";
 import { bootstrap } from "./store/bootstrap";
 import { useAiStore } from "./store/useAiStore";
 import {
@@ -572,6 +573,7 @@ function App() {
 						    side. An unpinned comments panel floats over the row edge,
 						    matching how it already overlays document content. */}
 						<AiSummaryPanel />
+						<SpecChecksPanel />
 						<CommentsPanel
 							open={commentsOpen}
 							pinned={commentsPinned}

--- a/src/lib/highlight.ts
+++ b/src/lib/highlight.ts
@@ -3,6 +3,8 @@ export interface HighlightTarget {
 	occurrence: number;
 	/** Optional tag carried in the returned found-map (typically a commentId). */
 	id?: string;
+	/** Extra class(es) on the <mark>, e.g. spec-check severity styling. */
+	className?: string;
 }
 
 const MARK_CLASS = "user-highlight";
@@ -239,7 +241,9 @@ function applyOne(container: HTMLElement, target: HighlightTarget): boolean {
 			range.setEnd(end.node, end.offset);
 			const fragment = range.extractContents();
 			const mark = document.createElement("mark");
-			mark.className = MARK_CLASS;
+			mark.className = target.className
+				? `${MARK_CLASS} ${target.className}`
+				: MARK_CLASS;
 			mark.dataset.highlightKey = key;
 			mark.appendChild(fragment);
 			range.insertNode(mark);

--- a/src/lib/specChecks.test.ts
+++ b/src/lib/specChecks.test.ts
@@ -103,6 +103,28 @@ describe("structural checks", () => {
 		expect(ids(runSpecChecks(repo))).toEqual([]);
 	});
 
+	it("includeArchived opts archived changes into the full check set", () => {
+		const spec = "### Requirement: R\nThe system must respond quickly.\n";
+		const repo = makeRepo([
+			makeChange({
+				archived: true,
+				proposal: null,
+				specs: { search: spec },
+				tasks: "- [x] wire add-search search flow",
+			}),
+		]);
+		const results = runSpecChecks(repo, { includeArchived: true });
+		const found = ids(results);
+		expect(found).toContain("SL001");
+		expect(found).toContain("SL020");
+		expect(found).toContain("SL022");
+		expect(results.find((r) => r.id === "SL001")?.changeKey).toBe(
+			"archive/add-search",
+		);
+		// An archived change naming its own slug is not a stale reference.
+		expect(found).not.toContain("SL011");
+	});
+
 	it("SL003 flags a delta for an unknown capability without ADDED", () => {
 		const spec = "## MODIFIED Requirements\n\n### Requirement: X\n\nBody.\n";
 		const repo = makeRepo(
@@ -313,6 +335,61 @@ describe("language checks", () => {
 		);
 		const finding = results.find((r) => r.id === "SL022");
 		expect(finding?.snippet).toBe("The system must respond quickly.");
+	});
+});
+
+describe("canonical repo specs", () => {
+	function repoWithSpec(content: string): Repo {
+		const repo = makeRepo([makeChange()], ["search"]);
+		repo.repoSpecs[0].content = content;
+		return repo;
+	}
+
+	it("runs structure and language checks with no owning change", () => {
+		const results = runSpecChecks(
+			repoWithSpec(
+				[
+					"### Requirement: Search",
+					"The system must respond quickly.",
+					"#### Scenario: bad",
+					"- WHEN the user types",
+				].join("\n"),
+			),
+		);
+		const ids = results.map((r) => r.id);
+		expect(ids).toContain("SL020");
+		expect(ids).toContain("SL022");
+		expect(ids).toContain("SL004");
+		for (const r of results) {
+			expect(r.changeKey).toBeNull();
+			expect(r.capability).toBe("search");
+		}
+	});
+
+	it("maps canonical findings to the spec viewer documentId", () => {
+		const results = runSpecChecks(
+			repoWithSpec("### Requirement: R\nThe system must respond.\n"),
+		);
+		const finding = results.find((r) => r.id === "SL020");
+		expect(finding).toBeDefined();
+		expect(finding && findingDocumentId(null, finding)).toBe("spec:search");
+	});
+
+	it("SL010 spans canonical specs and deltas across capabilities", () => {
+		const heading = "### Requirement: Reject over-limit input";
+		const repo = makeRepo(
+			[
+				makeChange({
+					specs: { ui: `${heading}\nThe ui MUST reject.\n` },
+					tasks: "- [ ] ui",
+				}),
+			],
+			["api"],
+		);
+		repo.repoSpecs[0].content = `${heading}\nThe api MUST reject.\n`;
+		const results = runSpecChecks(repo).filter((r) => r.id === "SL010");
+		expect(results).toHaveLength(2);
+		expect(results.map((r) => r.capability).sort()).toEqual(["api", "ui"]);
 	});
 });
 

--- a/src/lib/specChecks.test.ts
+++ b/src/lib/specChecks.test.ts
@@ -1,0 +1,384 @@
+import { describe, expect, it } from "vitest";
+import type { Change, Repo, RepoSpecDoc } from "./repoLoader";
+import { DEFAULT_SCHEMA } from "./schema";
+import {
+	changeKeyOf,
+	checkHighlightTargets,
+	checksForChange,
+	countBySeverity,
+	findingDocumentId,
+	maxSeverity,
+	runSpecChecks,
+	type SpecCheckResult,
+} from "./specChecks";
+
+const PROPOSAL = "## Why\n\nBecause.\n";
+const TASKS = "## Tasks\n\n- [ ] wire the search capability\n";
+
+function makeChange(overrides: Partial<Change> = {}): Change {
+	const specs = overrides.specs ?? {};
+	const documentFiles: Change["documentFiles"] = {};
+	const proposal =
+		overrides.proposal !== undefined ? overrides.proposal : PROPOSAL;
+	const tasks = overrides.tasks !== undefined ? overrides.tasks : TASKS;
+	if (proposal !== null) {
+		documentFiles.proposal = [
+			{ name: "proposal", path: "proposal.md", content: proposal },
+		];
+	}
+	if (tasks !== null) {
+		documentFiles.tasks = [{ name: "tasks", path: "tasks.md", content: tasks }];
+	}
+	if (Object.keys(specs).length > 0) {
+		documentFiles.specs = Object.entries(specs).map(([cap, content]) => ({
+			name: cap,
+			path: `specs/${cap}/spec.md`,
+			content,
+		}));
+	}
+	return {
+		slug: "add-search",
+		name: "Add Search",
+		archived: false,
+		createdAt: null,
+		archivedAt: null,
+		schema: DEFAULT_SCHEMA,
+		configYaml: null,
+		schemaYaml: null,
+		documents: {},
+		documentFiles,
+		specs,
+		proposal,
+		tasks,
+		authorship: null,
+		...overrides,
+	};
+}
+
+function makeRepo(changes: Change[], capabilities: string[] = []): Repo {
+	const repoSpecs: RepoSpecDoc[] = capabilities.map((capability) => ({
+		capability,
+		content: "# Spec",
+		path: `specs/${capability}/spec.md`,
+		authorship: null,
+	}));
+	return {
+		id: "/tmp/repo",
+		name: "repo",
+		type: "local",
+		hasGit: false,
+		headSha: null,
+		schema: DEFAULT_SCHEMA,
+		config: null,
+		configYaml: null,
+		schemaYaml: null,
+		changes,
+		repoSpecs,
+		schemas: [],
+		folders: [],
+	};
+}
+
+function ids(results: SpecCheckResult[]): string[] {
+	return results.map((r) => r.id);
+}
+
+describe("structural checks", () => {
+	it("SL001/SL002 flag missing proposal and tasks", () => {
+		const repo = makeRepo([makeChange({ proposal: null, tasks: null })]);
+		const results = runSpecChecks(repo);
+		expect(ids(results)).toContain("SL001");
+		expect(ids(results)).toContain("SL002");
+	});
+
+	it("stays quiet on a complete change", () => {
+		const repo = makeRepo([makeChange()]);
+		expect(runSpecChecks(repo)).toEqual([]);
+	});
+
+	it("skips archived changes for structural checks", () => {
+		const repo = makeRepo([
+			makeChange({ archived: true, proposal: null, tasks: null }),
+		]);
+		expect(ids(runSpecChecks(repo))).toEqual([]);
+	});
+
+	it("SL003 flags a delta for an unknown capability without ADDED", () => {
+		const spec = "## MODIFIED Requirements\n\n### Requirement: X\n\nBody.\n";
+		const repo = makeRepo(
+			[makeChange({ specs: { ghost: spec }, tasks: "- [ ] ghost work" })],
+			["search"],
+		);
+		const results = runSpecChecks(repo);
+		expect(ids(results)).toContain("SL003");
+		const finding = results.find((r) => r.id === "SL003");
+		expect(finding?.tab).toBe("specs");
+		expect(finding?.file).toBe("ghost");
+	});
+
+	it("SL003 accepts a new capability introduced via ADDED", () => {
+		const spec = "## ADDED Requirements\n\n### Requirement: X\n\nBody.\n";
+		const repo = makeRepo(
+			[makeChange({ specs: { "brand-new": spec }, tasks: "- [ ] brand-new" })],
+			["search"],
+		);
+		expect(ids(runSpecChecks(repo))).not.toContain("SL003");
+	});
+
+	it("SL004 flags WHEN without THEN and orphaned scenarios", () => {
+		const spec = [
+			"## ADDED Requirements",
+			"### Requirement: Search MUST return results",
+			"#### Scenario: query entered",
+			"- WHEN the user types a query",
+			"- the list updates",
+			"",
+			"## Notes",
+			"#### Scenario: orphaned",
+			"- WHEN something",
+			"- THEN something",
+		].join("\n");
+		const repo = makeRepo([
+			makeChange({ specs: { search: spec }, tasks: "- [ ] search" }),
+		]);
+		const results = runSpecChecks(repo).filter((r) => r.id === "SL004");
+		expect(results).toHaveLength(2);
+		expect(results.map((r) => r.message).join(" ")).toMatch(/WHEN.*no THEN/);
+		expect(results.map((r) => r.message).join(" ")).toMatch(
+			/no owning requirement/,
+		);
+	});
+
+	it("SL004 ignores keywords inside fenced code blocks", () => {
+		const spec = [
+			"## ADDED Requirements",
+			"### Requirement: Search MUST work",
+			"#### Scenario: ok",
+			"- WHEN the user types",
+			"- THEN results appear",
+			"```",
+			"#### Scenario: fake",
+			"WHEN inside a fence",
+			"```",
+		].join("\n");
+		const repo = makeRepo([
+			makeChange({ specs: { search: spec }, tasks: "- [ ] search" }),
+		]);
+		expect(ids(runSpecChecks(repo))).not.toContain("SL004");
+	});
+
+	it("SL005 flags a requirement heading with an empty body", () => {
+		const spec = [
+			"## ADDED Requirements",
+			"### Requirement: Empty one",
+			"### Requirement: Full one",
+			"The system MUST respond.",
+		].join("\n");
+		const repo = makeRepo([
+			makeChange({ specs: { search: spec }, tasks: "- [ ] search" }),
+		]);
+		const results = runSpecChecks(repo).filter((r) => r.id === "SL005");
+		expect(results).toHaveLength(1);
+		expect(results[0].message).toContain("Empty one");
+		expect(results[0].heading).toBe("Requirement: Empty one");
+	});
+
+	it("SL005 treats a requirement with only scenarios as non-empty", () => {
+		const spec = [
+			"## ADDED Requirements",
+			"### Requirement: Has scenarios",
+			"#### Scenario: ok",
+			"- WHEN a\n- THEN b",
+		].join("\n");
+		const repo = makeRepo([
+			makeChange({ specs: { search: spec }, tasks: "- [ ] search" }),
+		]);
+		expect(ids(runSpecChecks(repo))).not.toContain("SL005");
+	});
+});
+
+describe("consistency checks", () => {
+	it("SL010 flags near-duplicate requirements across capabilities", () => {
+		const a =
+			"### Requirement: Reject over-limit input\nThe api MUST reject.\n";
+		const b =
+			"### Requirement: Reject  over-limit input!\nThe ui MUST reject.\n";
+		const repo = makeRepo([
+			makeChange({
+				specs: { api: a, ui: b },
+				tasks: "- [ ] api and ui",
+			}),
+		]);
+		const results = runSpecChecks(repo).filter((r) => r.id === "SL010");
+		expect(results).toHaveLength(2);
+	});
+
+	it("SL011 flags an active change referencing an archived slug", () => {
+		const archived = makeChange({
+			slug: "old-search",
+			archived: true,
+			tasks: "- [x] done",
+		});
+		const current = makeChange({
+			proposal: "Builds on old-search groundwork.\n",
+		});
+		const repo = makeRepo([archived, current]);
+		const results = runSpecChecks(repo).filter((r) => r.id === "SL011");
+		expect(results).toHaveLength(1);
+		expect(results[0].changeKey).toBe("add-search");
+	});
+
+	it("SL012 flags tasks that never mention a touched capability", () => {
+		const spec = "### Requirement: R\nThe system MUST respond.\n";
+		const repo = makeRepo([
+			makeChange({ specs: { search: spec }, tasks: "- [ ] unrelated work" }),
+		]);
+		expect(ids(runSpecChecks(repo))).toContain("SL012");
+	});
+
+	it("SL013 flags complete-but-active and archived-but-incomplete", () => {
+		const completeActive = makeChange({ tasks: "- [x] a\n- [x] b" });
+		const incompleteArchived = makeChange({
+			slug: "old-thing",
+			archived: true,
+			tasks: "- [ ] a\n- [x] b",
+		});
+		const repo = makeRepo([completeActive, incompleteArchived]);
+		const results = runSpecChecks(repo).filter((r) => r.id === "SL013");
+		expect(results).toHaveLength(2);
+		expect(results.map((r) => r.changeKey).sort()).toEqual([
+			"add-search",
+			"archive/old-thing",
+		]);
+	});
+});
+
+describe("language checks", () => {
+	function specRepo(line: string): Repo {
+		const spec = `### Requirement: R\n${line}\n`;
+		return makeRepo([
+			makeChange({ specs: { search: spec }, tasks: "- [ ] search" }),
+		]);
+	}
+
+	it("SL020 flags lowercase modal verbs", () => {
+		const results = runSpecChecks(specRepo("The system must respond."));
+		expect(ids(results)).toContain("SL020");
+	});
+
+	it("SL020 ignores uppercase modals and inline code", () => {
+		expect(
+			ids(runSpecChecks(specRepo("The system MUST respond."))),
+		).not.toContain("SL020");
+		expect(
+			ids(runSpecChecks(specRepo("Set `must_retry` in the config."))),
+		).not.toContain("SL020");
+	});
+
+	it("SL021 flags conflicting modality in one clause", () => {
+		const results = runSpecChecks(
+			specRepo("The system SHOULD retry and MUST log."),
+		);
+		expect(ids(results)).toContain("SL021");
+	});
+
+	it("SL022 flags ambiguity terms including multiword ones", () => {
+		expect(
+			ids(runSpecChecks(specRepo("The system MUST respond quickly."))),
+		).toContain("SL022");
+		expect(ids(runSpecChecks(specRepo("Retries happen as needed.")))).toContain(
+			"SL022",
+		);
+	});
+
+	it("SL023 fires only in normative sentences", () => {
+		expect(
+			ids(runSpecChecks(specRepo("The system MUST retain some entries."))),
+		).toContain("SL023");
+		expect(
+			ids(runSpecChecks(specRepo("There are some entries in the cache."))),
+		).not.toContain("SL023");
+	});
+
+	it("attaches the nearest heading for deep-linking", () => {
+		const results = runSpecChecks(specRepo("The system must respond."));
+		const finding = results.find((r) => r.id === "SL020");
+		expect(finding?.heading).toBe("Requirement: R");
+		expect(finding?.tab).toBe("specs");
+	});
+
+	it("carries the offending line as a render-matched snippet", () => {
+		const results = runSpecChecks(
+			specRepo("- The system **must** respond quickly."),
+		);
+		const finding = results.find((r) => r.id === "SL022");
+		expect(finding?.snippet).toBe("The system must respond quickly.");
+	});
+});
+
+describe("highlight targets", () => {
+	it("builds severity-classed underline targets for one document", () => {
+		const spec = [
+			"### Requirement: R",
+			"- The system MUST respond quickly.",
+		].join("\n");
+		const change = makeChange({
+			specs: { search: spec },
+			tasks: "- [ ] search",
+		});
+		const repo = makeRepo([change]);
+		const results = runSpecChecks(repo);
+		const finding = results.find((r) => r.id === "SL022");
+		expect(finding).toBeDefined();
+		const docId = finding && findingDocumentId(change, finding);
+		expect(docId).toBe("add-search/specs");
+		const targets = checkHighlightTargets(repo, results, docId as string);
+		expect(targets).toHaveLength(1);
+		expect(targets[0].text).toBe("The system MUST respond quickly.");
+		expect(targets[0].className).toContain("spec-check-warning");
+		expect(checkHighlightTargets(repo, results, "other/doc")).toEqual([]);
+	});
+
+	it("keeps the highest severity when findings share a line", () => {
+		const spec = [
+			"### Requirement: R",
+			"- The system must respond quickly.",
+		].join("\n");
+		const change = makeChange({
+			specs: { search: spec },
+			tasks: "- [ ] search",
+		});
+		const repo = makeRepo([change]);
+		// SL020 (warning) and SL022 (warning) share the line; dedupe keeps one.
+		const targets = checkHighlightTargets(
+			repo,
+			runSpecChecks(repo),
+			"add-search/specs",
+		);
+		const lineTargets = targets.filter(
+			(t) => t.text === "The system must respond quickly.",
+		);
+		expect(lineTargets).toHaveLength(1);
+	});
+});
+
+describe("helpers", () => {
+	it("countBySeverity and maxSeverity aggregate correctly", () => {
+		const results = runSpecChecks(
+			makeRepo([makeChange({ proposal: null, tasks: null })]),
+		);
+		const counts = countBySeverity(results);
+		expect(counts.errors).toBe(2);
+		expect(counts.total).toBe(2);
+		expect(maxSeverity(counts)).toBe("error");
+		expect(maxSeverity(countBySeverity([]))).toBeNull();
+	});
+
+	it("checksForChange filters by change key", () => {
+		const a = makeChange({ proposal: null });
+		const b = makeChange({ slug: "other-change", tasks: null });
+		const results = runSpecChecks(makeRepo([a, b]));
+		expect(ids(checksForChange(results, changeKeyOf(a)))).toEqual(["SL001"]);
+		expect(ids(checksForChange(results, changeKeyOf(b)))).toEqual(["SL002"]);
+	});
+});

--- a/src/lib/specChecks.ts
+++ b/src/lib/specChecks.ts
@@ -1,0 +1,562 @@
+/**
+ * Deterministic spec linting ("Checks", docs/design/checks-and-claims.md
+ * feature 1). Pure module - no Tauri imports (the design doc requires the
+ * lint engine to stay extractable into a CLI later).
+ *
+ * Scope decisions for v1:
+ * - Checks run over the changes of a loaded repo. Archived changes are
+ *   historical records, so they are skipped except where the check is about
+ *   the archive state itself (SL011 reference targets, SL013 inverse).
+ * - Language checks (SL02x) run on spec deltas only, where prose is
+ *   normative; proposals and tasks are free-form.
+ * - SL003 tolerates deltas that introduce a capability (an ADDED section):
+ *   a delta for a brand-new capability is the normal way capabilities are
+ *   born, not an error.
+ */
+
+import type { HighlightTarget } from "./highlight";
+import type { Change, Repo } from "./repoLoader";
+import {
+	AMBIGUITY_TERMS,
+	CHECKS,
+	type CheckId,
+	type CheckSeverity,
+	formatCheckMessage,
+	UNBOUNDED_QUANTIFIERS,
+} from "./specChecksConfig";
+import { countTaskCompletion } from "./tasksCompletion";
+
+export type { CheckId, CheckSeverity } from "./specChecksConfig";
+
+export interface SpecCheckResult {
+	/** Stable check id, e.g. "SL004". User-visible and greppable. */
+	id: CheckId;
+	severity: CheckSeverity;
+	message: string;
+	/** Owning change key: "archive/" prefix + slug for archived changes. */
+	changeKey: string;
+	/** Artifact/tab id to open when deep-linking, when known. */
+	tab: string | null;
+	/** File name within a multi-file tab (e.g. a spec delta), when known. */
+	file: string | null;
+	/** Nearest heading text above the finding, for scroll deep-linking. */
+	heading: string | null;
+	/**
+	 * Offending text as it renders in the document (markdown syntax stripped),
+	 * for highlight deep-linking. Falls back to `heading` when null.
+	 */
+	snippet: string | null;
+}
+
+export interface CheckCounts {
+	errors: number;
+	warnings: number;
+	infos: number;
+	total: number;
+}
+
+const MODALS = ["MUST", "SHALL", "SHOULD", "MAY"] as const;
+const MODAL_REGEX = new RegExp(`\\b(${MODALS.join("|")})\\b`, "g");
+const HAS_MODAL = new RegExp(`\\b(${MODALS.join("|")})\\b`);
+
+export function changeKeyOf(change: Change): string {
+	return `${change.archived ? "archive/" : ""}${change.slug}`;
+}
+
+export function countBySeverity(results: SpecCheckResult[]): CheckCounts {
+	const counts = { errors: 0, warnings: 0, infos: 0, total: results.length };
+	for (const r of results) {
+		if (r.severity === "error") counts.errors++;
+		else if (r.severity === "warning") counts.warnings++;
+		else counts.infos++;
+	}
+	return counts;
+}
+
+export function maxSeverity(counts: CheckCounts): CheckSeverity | null {
+	if (counts.errors > 0) return "error";
+	if (counts.warnings > 0) return "warning";
+	if (counts.infos > 0) return "info";
+	return null;
+}
+
+/** Results belonging to one change, errors first, stable id order within. */
+export function checksForChange(
+	results: SpecCheckResult[],
+	changeKey: string,
+): SpecCheckResult[] {
+	return results.filter((r) => r.changeKey === changeKey);
+}
+
+/**
+ * MarkdownView documentId a finding renders under: `<slug>/<tab>` normally,
+ * `<slug>/<tab>/<file>` when the tab resolves to multiple files. Null when
+ * the finding has no tab (change-level findings like SL001).
+ */
+export function findingDocumentId(
+	change: Change,
+	result: SpecCheckResult,
+): string | null {
+	if (!result.tab) return null;
+	const tabFiles = change.documentFiles[result.tab] ?? [];
+	return tabFiles.length > 1 && result.file
+		? `${change.slug}/${result.tab}/${result.file}`
+		: `${change.slug}/${result.tab}`;
+}
+
+/**
+ * Findings anchored in one rendered document, grouped by the text they
+ * anchor to. Results arrive sorted errors-first, so each group's first entry
+ * carries the highest severity. Used for the wavy underlines and their hover
+ * diagnostics.
+ */
+export function checksByAnchorText(
+	repo: Repo,
+	results: SpecCheckResult[],
+	documentId: string,
+): Map<string, SpecCheckResult[]> {
+	const byText = new Map<string, SpecCheckResult[]>();
+	for (const result of results) {
+		const change = repo.changes.find(
+			(c) => changeKeyOf(c) === result.changeKey,
+		);
+		if (!change || findingDocumentId(change, result) !== documentId) continue;
+		const text = result.snippet ?? result.heading;
+		if (!text) continue;
+		const group = byText.get(text);
+		if (group) group.push(result);
+		else byText.set(text, [result]);
+	}
+	return byText;
+}
+
+/**
+ * Highlight targets for the findings anchored in one rendered document, for
+ * the IDE-style wavy underlines. One per anchor text, classed by the highest
+ * severity among the findings sharing it.
+ */
+export function checkHighlightTargets(
+	repo: Repo,
+	results: SpecCheckResult[],
+	documentId: string,
+): HighlightTarget[] {
+	return [...checksByAnchorText(repo, results, documentId).entries()].map(
+		([text, findings]) => ({
+			text,
+			occurrence: 1,
+			className: `spec-check spec-check-${findings[0].severity}`,
+		}),
+	);
+}
+
+const SEVERITY_ORDER: Record<CheckSeverity, number> = {
+	error: 0,
+	warning: 1,
+	info: 2,
+};
+
+interface ScannedLine {
+	text: string;
+	/** Original markdown line, for snippet extraction. */
+	raw: string;
+	/** Nearest heading text above this line (null before the first heading). */
+	heading: string | null;
+}
+
+const FENCE = /^\s*(```|~~~)/;
+const HEADING = /^(#{1,6})\s+(.+?)\s*#*\s*$/;
+
+/**
+ * Splits markdown into scannable lines: fenced code blocks are dropped,
+ * inline code spans are blanked (so `must` in code never triggers language
+ * checks), and each line carries the nearest heading above it.
+ */
+function scanLines(markdown: string): ScannedLine[] {
+	const out: ScannedLine[] = [];
+	let inFence = false;
+	let heading: string | null = null;
+	for (const line of markdown.split("\n")) {
+		if (FENCE.test(line)) {
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) continue;
+		const h = HEADING.exec(line);
+		if (h) {
+			heading = h[2].replace(/`/g, "").trim();
+			continue;
+		}
+		out.push({ text: line.replace(/`[^`]*`/g, " "), raw: line, heading });
+	}
+	return out;
+}
+
+/**
+ * Reduces a markdown source line to the text the reader sees, so the
+ * highlight mechanism (which matches rendered text) can locate it. List
+ * markers, checkboxes, strong-emphasis markers, and backticks render as
+ * nothing; single *emphasis* is left alone (stripping it would corrupt
+ * legitimate asterisks more often than it would help).
+ */
+function toSnippet(raw: string): string | null {
+	const cleaned = raw
+		.replace(/^\s*(?:[-*+]\s+)?(?:\[[xX ]\]\s+)?/, "")
+		.replace(/^\s*\d+\.\s+/, "")
+		.replace(/\*\*|__/g, "")
+		.replace(/`/g, "")
+		.trim();
+	return cleaned || null;
+}
+
+interface HeadingBlock {
+	/** Heading text without the leading #s. */
+	text: string;
+	depth: number;
+	/** Non-blank body lines before the next heading of any depth. */
+	body: string[];
+	/** Nearest requirement heading above (for scenario ownership). */
+	owningRequirement: string | null;
+}
+
+const REQUIREMENT_HEADING = /^requirement\b/i;
+const SCENARIO_HEADING = /^scenario\b/i;
+
+/** Extracts heading blocks with fence awareness. */
+function scanHeadingBlocks(markdown: string): HeadingBlock[] {
+	const blocks: HeadingBlock[] = [];
+	let inFence = false;
+	let current: HeadingBlock | null = null;
+	let lastRequirement: { text: string; depth: number } | null = null;
+	for (const line of markdown.split("\n")) {
+		if (FENCE.test(line)) {
+			inFence = !inFence;
+			continue;
+		}
+		if (inFence) continue;
+		const h = HEADING.exec(line);
+		if (h) {
+			const depth = h[1].length;
+			const text = h[2].replace(/`/g, "").trim();
+			if (REQUIREMENT_HEADING.test(text)) {
+				lastRequirement = { text, depth };
+			} else if (lastRequirement && depth <= lastRequirement.depth) {
+				// A sibling or shallower non-requirement heading closes the
+				// requirement's scope - scenarios after it are orphaned.
+				lastRequirement = null;
+			}
+			current = {
+				text,
+				depth,
+				body: [],
+				owningRequirement:
+					REQUIREMENT_HEADING.test(text) || !lastRequirement
+						? null
+						: lastRequirement.text,
+			};
+			blocks.push(current);
+			continue;
+		}
+		if (current && line.trim() !== "") current.body.push(line);
+	}
+	return blocks;
+}
+
+/** Location of one spec-delta document inside a change's tab structure. */
+interface SpecDocRef {
+	capability: string;
+	content: string;
+	tab: string | null;
+	file: string | null;
+}
+
+/**
+ * Resolves each spec delta of a change to the artifact tab + file name the
+ * viewer would open it under, by matching `specs/<cap>/spec.md` paths against
+ * the change's resolved documentFiles.
+ */
+function specDocRefs(change: Change): SpecDocRef[] {
+	const refs: SpecDocRef[] = [];
+	for (const [capability, content] of Object.entries(change.specs)) {
+		const relPath = `specs/${capability}/spec.md`;
+		let tab: string | null = null;
+		let file: string | null = null;
+		for (const [artifactId, files] of Object.entries(change.documentFiles)) {
+			const match = files.find(
+				(f) => f.path.toLowerCase() === relPath.toLowerCase(),
+			);
+			if (match) {
+				tab = artifactId;
+				file = match.name;
+				break;
+			}
+		}
+		refs.push({ capability, content, tab, file });
+	}
+	return refs;
+}
+
+/** Tab id whose resolved files include the given change-relative path. */
+function tabForPath(change: Change, relPath: string): string | null {
+	for (const [artifactId, files] of Object.entries(change.documentFiles)) {
+		if (files.some((f) => f.path.toLowerCase() === relPath.toLowerCase())) {
+			return artifactId;
+		}
+	}
+	return null;
+}
+
+/** Requirement text normalization for SL010 near-duplicate comparison. */
+function normalizeRequirementText(text: string): string {
+	return text
+		.toLowerCase()
+		.replace(/^requirement[:\s]*/, "")
+		.replace(/[^a-z0-9\s]/g, " ")
+		.replace(/\s+/g, " ")
+		.trim();
+}
+
+function escapeRegex(text: string): string {
+	return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+const ADDED_SECTION = /^#{1,6}\s+ADDED\b/im;
+
+export function runSpecChecks(repo: Repo): SpecCheckResult[] {
+	const results: SpecCheckResult[] = [];
+	const active = repo.changes.filter((c) => !c.archived);
+	const archived = repo.changes.filter((c) => c.archived);
+	const repoCapabilities = new Set(repo.repoSpecs.map((s) => s.capability));
+
+	// Requirement headings across all active deltas, for SL010.
+	const requirementIndex = new Map<
+		string,
+		{
+			capability: string;
+			changeKey: string;
+			heading: string;
+			ref: SpecDocRef;
+		}[]
+	>();
+
+	for (const change of active) {
+		const key = changeKeyOf(change);
+		const push = (
+			id: CheckId,
+			variant: string,
+			params: Record<string, string> = {},
+			loc?: Partial<
+				Pick<SpecCheckResult, "tab" | "file" | "heading" | "snippet">
+			>,
+		) => {
+			results.push({
+				id,
+				severity: CHECKS[id].severity,
+				message: formatCheckMessage(id, variant, params),
+				changeKey: key,
+				tab: loc?.tab ?? null,
+				file: loc?.file ?? null,
+				heading: loc?.heading ?? null,
+				snippet: loc?.snippet ?? null,
+			});
+		};
+
+		// SL001 / SL002 - required documents.
+		if (change.proposal === null) {
+			push("SL001", "default");
+		}
+		if (change.tasks === null) {
+			push("SL002", "default");
+		}
+
+		const specRefs = specDocRefs(change);
+
+		for (const ref of specRefs) {
+			const loc = { tab: ref.tab, file: ref.file };
+
+			// SL003 - delta for a capability that neither exists nor is added.
+			if (
+				!repoCapabilities.has(ref.capability) &&
+				!ADDED_SECTION.test(ref.content)
+			) {
+				push("SL003", "default", { capability: ref.capability }, loc);
+			}
+
+			// SL004 / SL005 - heading-block structure.
+			const blocks = scanHeadingBlocks(ref.content);
+			for (const block of blocks) {
+				const blockLoc = { ...loc, heading: block.text };
+				if (SCENARIO_HEADING.test(block.text)) {
+					const params = { scenario: block.text };
+					if (!block.owningRequirement) {
+						push("SL004", "orphanScenario", params, blockLoc);
+					}
+					const body = block.body.join("\n");
+					const hasWhen = /\bWHEN\b/.test(body);
+					const hasGiven = /\bGIVEN\b/.test(body);
+					const hasThen = /\bTHEN\b/.test(body);
+					if (hasWhen && !hasThen) {
+						push("SL004", "whenWithoutThen", params, blockLoc);
+					}
+					if (hasGiven && !hasThen) {
+						push("SL004", "givenWithoutThen", params, blockLoc);
+					}
+				}
+				if (REQUIREMENT_HEADING.test(block.text)) {
+					const followedByContent =
+						block.body.length > 0 ||
+						blocks.some((b) => b.owningRequirement === block.text);
+					if (!followedByContent) {
+						push("SL005", "default", { requirement: block.text }, blockLoc);
+					}
+					// Collect for SL010.
+					const normalized = normalizeRequirementText(block.text);
+					if (normalized) {
+						const entries = requirementIndex.get(normalized) ?? [];
+						entries.push({
+							capability: ref.capability,
+							changeKey: key,
+							heading: block.text,
+							ref,
+						});
+						requirementIndex.set(normalized, entries);
+					}
+				}
+			}
+
+			// SL020-SL023 - language checks on normative spec prose.
+			for (const line of scanLines(ref.content)) {
+				const lineLoc = {
+					...loc,
+					heading: line.heading,
+					snippet: toSnippet(line.raw),
+				};
+
+				// Case-sensitive on purpose: only fully lowercase forms are misuse.
+				const misuse = line.text.match(/\b(shall|must)\b/g);
+				if (misuse) {
+					push("SL020", "default", { word: misuse[0] }, lineLoc);
+				}
+
+				const modals = new Set(line.text.match(MODAL_REGEX) ?? []);
+				if (modals.size >= 2) {
+					push(
+						"SL021",
+						"default",
+						{ modals: [...modals].join(" + ") },
+						lineLoc,
+					);
+				}
+
+				for (const term of AMBIGUITY_TERMS) {
+					const re = new RegExp(`\\b${escapeRegex(term)}(?!\\w)`, "i");
+					if (re.test(line.text)) {
+						push("SL022", "default", { term }, lineLoc);
+					}
+				}
+
+				if (HAS_MODAL.test(line.text)) {
+					for (const q of UNBOUNDED_QUANTIFIERS) {
+						const re = new RegExp(`\\b${q}\\b`, "i");
+						if (re.test(line.text)) {
+							push("SL023", "default", { term: q }, lineLoc);
+						}
+					}
+				}
+			}
+		}
+
+		// SL011 - references to archived changes.
+		for (const other of archived) {
+			const re = new RegExp(`(^|[^\\w-])${escapeRegex(other.slug)}([^\\w-]|$)`);
+			const docs: [string, string | null][] = [
+				["proposal.md", change.proposal],
+				["tasks.md", change.tasks],
+			];
+			for (const [relPath, content] of docs) {
+				if (content && re.test(content)) {
+					push(
+						"SL011",
+						"default",
+						{ slug: other.slug },
+						{ tab: tabForPath(change, relPath), snippet: other.slug },
+					);
+					break;
+				}
+			}
+		}
+
+		// SL012 - tasks never mention any touched capability.
+		const capabilities = Object.keys(change.specs);
+		if (change.tasks && capabilities.length > 0) {
+			const tasksLower = change.tasks.toLowerCase();
+			const mentioned = capabilities.some((cap) =>
+				tasksLower.includes(cap.toLowerCase()),
+			);
+			if (!mentioned) {
+				push(
+					"SL012",
+					"default",
+					{ capabilities: capabilities.join(", ") },
+					{ tab: tabForPath(change, "tasks.md") },
+				);
+			}
+		}
+	}
+
+	// SL013 - task completion vs archive state (runs on all changes).
+	for (const change of repo.changes) {
+		if (!change.tasks) continue;
+		const { total, done } = countTaskCompletion(change.tasks);
+		if (total === 0) continue;
+		const pushTaskState = (variant: string, params: Record<string, string>) => {
+			results.push({
+				id: "SL013",
+				severity: CHECKS.SL013.severity,
+				message: formatCheckMessage("SL013", variant, params),
+				changeKey: changeKeyOf(change),
+				tab: tabForPath(change, "tasks.md"),
+				file: null,
+				heading: null,
+				snippet: null,
+			});
+		};
+		if (!change.archived && done === total) {
+			pushTaskState("readyToArchive", {});
+		}
+		if (change.archived && done < total) {
+			pushTaskState("archivedIncomplete", {
+				done: String(done),
+				total: String(total),
+			});
+		}
+	}
+
+	// SL010 - near-duplicate requirement text across capabilities.
+	for (const entries of requirementIndex.values()) {
+		const capabilities = new Set(entries.map((e) => e.capability));
+		if (capabilities.size < 2) continue;
+		for (const entry of entries) {
+			const others = [...capabilities].filter((c) => c !== entry.capability);
+			results.push({
+				id: "SL010",
+				severity: CHECKS.SL010.severity,
+				message: formatCheckMessage("SL010", "default", {
+					requirement: entry.heading,
+					others: others.join(", "),
+				}),
+				changeKey: entry.changeKey,
+				tab: entry.ref.tab,
+				file: entry.ref.file,
+				heading: entry.heading,
+				snippet: null,
+			});
+		}
+	}
+
+	return results.sort(
+		(a, b) =>
+			SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] ||
+			a.id.localeCompare(b.id) ||
+			a.changeKey.localeCompare(b.changeKey),
+	);
+}

--- a/src/lib/specChecks.ts
+++ b/src/lib/specChecks.ts
@@ -4,11 +4,17 @@
  * lint engine to stay extractable into a CLI later).
  *
  * Scope decisions for v1:
- * - Checks run over the changes of a loaded repo. Archived changes are
- *   historical records, so they are skipped except where the check is about
- *   the archive state itself (SL011 reference targets, SL013 inverse).
- * - Language checks (SL02x) run on spec deltas only, where prose is
- *   normative; proposals and tasks are free-form.
+ * - Change-level checks run over the changes of a loaded repo. Archived
+ *   changes are historical records, so by default they are skipped except
+ *   where the check is about the archive state itself (SL011 reference
+ *   targets, SL013 inverse). `options.includeArchived` opts archived
+ *   changes into the full set (settings.specChecksIncludeArchived).
+ * - Spec-content checks (SL004/SL005 structure, SL02x language, SL010
+ *   duplicates) run on active change deltas AND the canonical
+ *   `openspec/specs/<cap>/spec.md` files. Canonical-spec findings have no
+ *   owning change: `changeKey` is null and `capability` locates them.
+ * - Language checks are limited to spec documents, where prose is normative;
+ *   proposals and tasks are free-form.
  * - SL003 tolerates deltas that introduce a capability (an ADDED section):
  *   a delta for a brand-new capability is the normal way capabilities are
  *   born, not an error.
@@ -33,8 +39,13 @@ export interface SpecCheckResult {
 	id: CheckId;
 	severity: CheckSeverity;
 	message: string;
-	/** Owning change key: "archive/" prefix + slug for archived changes. */
-	changeKey: string;
+	/**
+	 * Owning change key ("archive/" prefix + slug), or null for findings in
+	 * canonical repo specs, which have no owning change.
+	 */
+	changeKey: string | null;
+	/** Capability the finding belongs to, when it lives in a spec document. */
+	capability: string | null;
 	/** Artifact/tab id to open when deep-linking, when known. */
 	tab: string | null;
 	/** File name within a multi-file tab (e.g. a spec delta), when known. */
@@ -54,10 +65,6 @@ export interface CheckCounts {
 	infos: number;
 	total: number;
 }
-
-const MODALS = ["MUST", "SHALL", "SHOULD", "MAY"] as const;
-const MODAL_REGEX = new RegExp(`\\b(${MODALS.join("|")})\\b`, "g");
-const HAS_MODAL = new RegExp(`\\b(${MODALS.join("|")})\\b`);
 
 export function changeKeyOf(change: Change): string {
 	return `${change.archived ? "archive/" : ""}${change.slug}`;
@@ -89,15 +96,19 @@ export function checksForChange(
 }
 
 /**
- * MarkdownView documentId a finding renders under: `<slug>/<tab>` normally,
- * `<slug>/<tab>/<file>` when the tab resolves to multiple files. Null when
- * the finding has no tab (change-level findings like SL001).
+ * MarkdownView documentId a finding renders under: `spec:<capability>` for
+ * canonical-spec findings, `<slug>/<tab>` for change docs (or
+ * `<slug>/<tab>/<file>` when the tab resolves to multiple files). Null when
+ * the finding has no anchored document (change-level findings like SL001).
  */
 export function findingDocumentId(
-	change: Change,
+	change: Change | null,
 	result: SpecCheckResult,
 ): string | null {
-	if (!result.tab) return null;
+	if (result.changeKey === null) {
+		return result.capability ? `spec:${result.capability}` : null;
+	}
+	if (!change || !result.tab) return null;
 	const tabFiles = change.documentFiles[result.tab] ?? [];
 	return tabFiles.length > 1 && result.file
 		? `${change.slug}/${result.tab}/${result.file}`
@@ -117,10 +128,10 @@ export function checksByAnchorText(
 ): Map<string, SpecCheckResult[]> {
 	const byText = new Map<string, SpecCheckResult[]>();
 	for (const result of results) {
-		const change = repo.changes.find(
-			(c) => changeKeyOf(c) === result.changeKey,
-		);
-		if (!change || findingDocumentId(change, result) !== documentId) continue;
+		const change = result.changeKey
+			? (repo.changes.find((c) => changeKeyOf(c) === result.changeKey) ?? null)
+			: null;
+		if (findingDocumentId(change, result) !== documentId) continue;
 		const text = result.snippet ?? result.heading;
 		if (!text) continue;
 		const group = byText.get(text);
@@ -261,6 +272,10 @@ function scanHeadingBlocks(markdown: string): HeadingBlock[] {
 	return blocks;
 }
 
+const MODALS = ["MUST", "SHALL", "SHOULD", "MAY"] as const;
+const MODAL_REGEX = new RegExp(`\\b(${MODALS.join("|")})\\b`, "g");
+const HAS_MODAL = new RegExp(`\\b(${MODALS.join("|")})\\b`);
+
 /** Location of one spec-delta document inside a change's tab structure. */
 interface SpecDocRef {
 	capability: string;
@@ -321,152 +336,171 @@ function escapeRegex(text: string): string {
 
 const ADDED_SECTION = /^#{1,6}\s+ADDED\b/im;
 
-export function runSpecChecks(repo: Repo): SpecCheckResult[] {
+/** Where a spec document lives, threaded through every finding it produces. */
+interface SpecDocLoc {
+	changeKey: string | null;
+	capability: string;
+	tab: string | null;
+	file: string | null;
+}
+
+interface RequirementEntry extends SpecDocLoc {
+	heading: string;
+}
+
+export interface SpecCheckOptions {
+	/** Also lint archived changes' documents and deltas. Default false. */
+	includeArchived?: boolean;
+}
+
+export function runSpecChecks(
+	repo: Repo,
+	options: SpecCheckOptions = {},
+): SpecCheckResult[] {
 	const results: SpecCheckResult[] = [];
-	const active = repo.changes.filter((c) => !c.archived);
+	const included = options.includeArchived
+		? repo.changes
+		: repo.changes.filter((c) => !c.archived);
 	const archived = repo.changes.filter((c) => c.archived);
 	const repoCapabilities = new Set(repo.repoSpecs.map((s) => s.capability));
 
-	// Requirement headings across all active deltas, for SL010.
-	const requirementIndex = new Map<
-		string,
-		{
-			capability: string;
-			changeKey: string;
-			heading: string;
-			ref: SpecDocRef;
-		}[]
-	>();
+	const emit = (
+		id: CheckId,
+		variant: string,
+		params: Record<string, string>,
+		loc: Partial<
+			Pick<
+				SpecCheckResult,
+				"changeKey" | "capability" | "tab" | "file" | "heading" | "snippet"
+			>
+		>,
+	) => {
+		results.push({
+			id,
+			severity: CHECKS[id].severity,
+			message: formatCheckMessage(id, variant, params),
+			changeKey: loc.changeKey ?? null,
+			capability: loc.capability ?? null,
+			tab: loc.tab ?? null,
+			file: loc.file ?? null,
+			heading: loc.heading ?? null,
+			snippet: loc.snippet ?? null,
+		});
+	};
 
-	for (const change of active) {
+	// Requirement headings across all spec docs (deltas + canonical), for SL010.
+	const requirementIndex = new Map<string, RequirementEntry[]>();
+
+	// SL004 / SL005 structure + SL02x language + SL010 collection, shared by
+	// change deltas and canonical repo specs.
+	const checkSpecDoc = (content: string, loc: SpecDocLoc) => {
+		const blocks = scanHeadingBlocks(content);
+		for (const block of blocks) {
+			const blockLoc = { ...loc, heading: block.text };
+			if (SCENARIO_HEADING.test(block.text)) {
+				const params = { scenario: block.text };
+				if (!block.owningRequirement) {
+					emit("SL004", "orphanScenario", params, blockLoc);
+				}
+				const body = block.body.join("\n");
+				const hasWhen = /\bWHEN\b/.test(body);
+				const hasGiven = /\bGIVEN\b/.test(body);
+				const hasThen = /\bTHEN\b/.test(body);
+				if (hasWhen && !hasThen) {
+					emit("SL004", "whenWithoutThen", params, blockLoc);
+				}
+				if (hasGiven && !hasThen) {
+					emit("SL004", "givenWithoutThen", params, blockLoc);
+				}
+			}
+			if (REQUIREMENT_HEADING.test(block.text)) {
+				const followedByContent =
+					block.body.length > 0 ||
+					blocks.some((b) => b.owningRequirement === block.text);
+				if (!followedByContent) {
+					emit("SL005", "default", { requirement: block.text }, blockLoc);
+				}
+				const normalized = normalizeRequirementText(block.text);
+				if (normalized) {
+					const entries = requirementIndex.get(normalized) ?? [];
+					entries.push({ ...loc, heading: block.text });
+					requirementIndex.set(normalized, entries);
+				}
+			}
+		}
+
+		for (const line of scanLines(content)) {
+			const lineLoc = {
+				...loc,
+				heading: line.heading,
+				snippet: toSnippet(line.raw),
+			};
+
+			// Case-sensitive on purpose: only fully lowercase forms are misuse.
+			const misuse = line.text.match(/\b(shall|must)\b/g);
+			if (misuse) {
+				emit("SL020", "default", { word: misuse[0] }, lineLoc);
+			}
+
+			const modals = new Set(line.text.match(MODAL_REGEX) ?? []);
+			if (modals.size >= 2) {
+				emit("SL021", "default", { modals: [...modals].join(" + ") }, lineLoc);
+			}
+
+			for (const term of AMBIGUITY_TERMS) {
+				const re = new RegExp(`\\b${escapeRegex(term)}(?!\\w)`, "i");
+				if (re.test(line.text)) {
+					emit("SL022", "default", { term }, lineLoc);
+				}
+			}
+
+			if (HAS_MODAL.test(line.text)) {
+				for (const q of UNBOUNDED_QUANTIFIERS) {
+					const re = new RegExp(`\\b${q}\\b`, "i");
+					if (re.test(line.text)) {
+						emit("SL023", "default", { term: q }, lineLoc);
+					}
+				}
+			}
+		}
+	};
+
+	for (const change of included) {
 		const key = changeKeyOf(change);
-		const push = (
-			id: CheckId,
-			variant: string,
-			params: Record<string, string> = {},
-			loc?: Partial<
-				Pick<SpecCheckResult, "tab" | "file" | "heading" | "snippet">
-			>,
-		) => {
-			results.push({
-				id,
-				severity: CHECKS[id].severity,
-				message: formatCheckMessage(id, variant, params),
-				changeKey: key,
-				tab: loc?.tab ?? null,
-				file: loc?.file ?? null,
-				heading: loc?.heading ?? null,
-				snippet: loc?.snippet ?? null,
-			});
-		};
+		const changeLoc = { changeKey: key };
 
 		// SL001 / SL002 - required documents.
 		if (change.proposal === null) {
-			push("SL001", "default");
+			emit("SL001", "default", {}, changeLoc);
 		}
 		if (change.tasks === null) {
-			push("SL002", "default");
+			emit("SL002", "default", {}, changeLoc);
 		}
 
-		const specRefs = specDocRefs(change);
-
-		for (const ref of specRefs) {
-			const loc = { tab: ref.tab, file: ref.file };
+		for (const ref of specDocRefs(change)) {
+			const loc: SpecDocLoc = {
+				changeKey: key,
+				capability: ref.capability,
+				tab: ref.tab,
+				file: ref.file,
+			};
 
 			// SL003 - delta for a capability that neither exists nor is added.
 			if (
 				!repoCapabilities.has(ref.capability) &&
 				!ADDED_SECTION.test(ref.content)
 			) {
-				push("SL003", "default", { capability: ref.capability }, loc);
+				emit("SL003", "default", { capability: ref.capability }, loc);
 			}
 
-			// SL004 / SL005 - heading-block structure.
-			const blocks = scanHeadingBlocks(ref.content);
-			for (const block of blocks) {
-				const blockLoc = { ...loc, heading: block.text };
-				if (SCENARIO_HEADING.test(block.text)) {
-					const params = { scenario: block.text };
-					if (!block.owningRequirement) {
-						push("SL004", "orphanScenario", params, blockLoc);
-					}
-					const body = block.body.join("\n");
-					const hasWhen = /\bWHEN\b/.test(body);
-					const hasGiven = /\bGIVEN\b/.test(body);
-					const hasThen = /\bTHEN\b/.test(body);
-					if (hasWhen && !hasThen) {
-						push("SL004", "whenWithoutThen", params, blockLoc);
-					}
-					if (hasGiven && !hasThen) {
-						push("SL004", "givenWithoutThen", params, blockLoc);
-					}
-				}
-				if (REQUIREMENT_HEADING.test(block.text)) {
-					const followedByContent =
-						block.body.length > 0 ||
-						blocks.some((b) => b.owningRequirement === block.text);
-					if (!followedByContent) {
-						push("SL005", "default", { requirement: block.text }, blockLoc);
-					}
-					// Collect for SL010.
-					const normalized = normalizeRequirementText(block.text);
-					if (normalized) {
-						const entries = requirementIndex.get(normalized) ?? [];
-						entries.push({
-							capability: ref.capability,
-							changeKey: key,
-							heading: block.text,
-							ref,
-						});
-						requirementIndex.set(normalized, entries);
-					}
-				}
-			}
-
-			// SL020-SL023 - language checks on normative spec prose.
-			for (const line of scanLines(ref.content)) {
-				const lineLoc = {
-					...loc,
-					heading: line.heading,
-					snippet: toSnippet(line.raw),
-				};
-
-				// Case-sensitive on purpose: only fully lowercase forms are misuse.
-				const misuse = line.text.match(/\b(shall|must)\b/g);
-				if (misuse) {
-					push("SL020", "default", { word: misuse[0] }, lineLoc);
-				}
-
-				const modals = new Set(line.text.match(MODAL_REGEX) ?? []);
-				if (modals.size >= 2) {
-					push(
-						"SL021",
-						"default",
-						{ modals: [...modals].join(" + ") },
-						lineLoc,
-					);
-				}
-
-				for (const term of AMBIGUITY_TERMS) {
-					const re = new RegExp(`\\b${escapeRegex(term)}(?!\\w)`, "i");
-					if (re.test(line.text)) {
-						push("SL022", "default", { term }, lineLoc);
-					}
-				}
-
-				if (HAS_MODAL.test(line.text)) {
-					for (const q of UNBOUNDED_QUANTIFIERS) {
-						const re = new RegExp(`\\b${q}\\b`, "i");
-						if (re.test(line.text)) {
-							push("SL023", "default", { term: q }, lineLoc);
-						}
-					}
-				}
-			}
+			checkSpecDoc(ref.content, loc);
 		}
 
-		// SL011 - references to archived changes.
+		// SL011 - references to archived changes. Self-references are skipped:
+		// with includeArchived on, an archived change naming its own slug in
+		// its proposal is not a stale reference.
 		for (const other of archived) {
+			if (changeKeyOf(other) === key) continue;
 			const re = new RegExp(`(^|[^\\w-])${escapeRegex(other.slug)}([^\\w-]|$)`);
 			const docs: [string, string | null][] = [
 				["proposal.md", change.proposal],
@@ -474,11 +508,15 @@ export function runSpecChecks(repo: Repo): SpecCheckResult[] {
 			];
 			for (const [relPath, content] of docs) {
 				if (content && re.test(content)) {
-					push(
+					emit(
 						"SL011",
 						"default",
 						{ slug: other.slug },
-						{ tab: tabForPath(change, relPath), snippet: other.slug },
+						{
+							...changeLoc,
+							tab: tabForPath(change, relPath),
+							snippet: other.slug,
+						},
 					);
 					break;
 				}
@@ -493,14 +531,25 @@ export function runSpecChecks(repo: Repo): SpecCheckResult[] {
 				tasksLower.includes(cap.toLowerCase()),
 			);
 			if (!mentioned) {
-				push(
+				emit(
 					"SL012",
 					"default",
 					{ capabilities: capabilities.join(", ") },
-					{ tab: tabForPath(change, "tasks.md") },
+					{ ...changeLoc, tab: tabForPath(change, "tasks.md") },
 				);
 			}
 		}
+	}
+
+	// Canonical repo specs: same structure/language/duplicate checks, no
+	// owning change.
+	for (const spec of repo.repoSpecs) {
+		checkSpecDoc(spec.content, {
+			changeKey: null,
+			capability: spec.capability,
+			tab: null,
+			file: null,
+		});
 	}
 
 	// SL013 - task completion vs archive state (runs on all changes).
@@ -508,26 +557,20 @@ export function runSpecChecks(repo: Repo): SpecCheckResult[] {
 		if (!change.tasks) continue;
 		const { total, done } = countTaskCompletion(change.tasks);
 		if (total === 0) continue;
-		const pushTaskState = (variant: string, params: Record<string, string>) => {
-			results.push({
-				id: "SL013",
-				severity: CHECKS.SL013.severity,
-				message: formatCheckMessage("SL013", variant, params),
-				changeKey: changeKeyOf(change),
-				tab: tabForPath(change, "tasks.md"),
-				file: null,
-				heading: null,
-				snippet: null,
-			});
+		const loc = {
+			changeKey: changeKeyOf(change),
+			tab: tabForPath(change, "tasks.md"),
 		};
 		if (!change.archived && done === total) {
-			pushTaskState("readyToArchive", {});
+			emit("SL013", "readyToArchive", {}, loc);
 		}
 		if (change.archived && done < total) {
-			pushTaskState("archivedIncomplete", {
-				done: String(done),
-				total: String(total),
-			});
+			emit(
+				"SL013",
+				"archivedIncomplete",
+				{ done: String(done), total: String(total) },
+				loc,
+			);
 		}
 	}
 
@@ -537,19 +580,12 @@ export function runSpecChecks(repo: Repo): SpecCheckResult[] {
 		if (capabilities.size < 2) continue;
 		for (const entry of entries) {
 			const others = [...capabilities].filter((c) => c !== entry.capability);
-			results.push({
-				id: "SL010",
-				severity: CHECKS.SL010.severity,
-				message: formatCheckMessage("SL010", "default", {
-					requirement: entry.heading,
-					others: others.join(", "),
-				}),
-				changeKey: entry.changeKey,
-				tab: entry.ref.tab,
-				file: entry.ref.file,
-				heading: entry.heading,
-				snippet: null,
-			});
+			emit(
+				"SL010",
+				"default",
+				{ requirement: entry.heading, others: others.join(", ") },
+				{ ...entry, snippet: null },
+			);
 		}
 	}
 
@@ -557,6 +593,6 @@ export function runSpecChecks(repo: Repo): SpecCheckResult[] {
 		(a, b) =>
 			SEVERITY_ORDER[a.severity] - SEVERITY_ORDER[b.severity] ||
 			a.id.localeCompare(b.id) ||
-			a.changeKey.localeCompare(b.changeKey),
+			(a.changeKey ?? "").localeCompare(b.changeKey ?? ""),
 	);
 }

--- a/src/lib/specChecksConfig.ts
+++ b/src/lib/specChecksConfig.ts
@@ -1,0 +1,144 @@
+/**
+ * Spec-check registry: the single source of truth for check ids, severities,
+ * titles, message templates, and word lists. The engine (specChecks.ts) holds
+ * only detection logic; everything user-facing or tunable lives here.
+ *
+ * Message templates use {placeholder} syntax, filled by formatCheckMessage.
+ * Pure module - keep it free of Tauri imports so the lint core stays
+ * extractable (see docs/design/checks-and-claims.md).
+ */
+
+export type CheckSeverity = "error" | "warning" | "info";
+
+export interface CheckDefinition {
+	severity: CheckSeverity;
+	/** Short human name for the check, e.g. shown in future settings UI. */
+	title: string;
+	/** Message templates by variant; most checks only have `default`. */
+	messages: Record<string, string>;
+}
+
+export const CHECKS = {
+	SL001: {
+		severity: "error",
+		title: "Missing proposal",
+		messages: { default: "Change has no proposal.md." },
+	},
+	SL002: {
+		severity: "error",
+		title: "Missing tasks",
+		messages: { default: "Change has no tasks.md." },
+	},
+	SL003: {
+		severity: "error",
+		title: "Unknown capability",
+		messages: {
+			default:
+				'Spec delta targets capability "{capability}", which does not exist in specs/ and is not introduced by an ADDED section.',
+		},
+	},
+	SL004: {
+		severity: "error",
+		title: "Malformed EARS/Gherkin block",
+		messages: {
+			orphanScenario:
+				'Scenario "{scenario}" has no owning requirement heading.',
+			whenWithoutThen: 'Scenario "{scenario}" has a WHEN clause but no THEN.',
+			givenWithoutThen: 'Scenario "{scenario}" has a GIVEN clause but no THEN.',
+		},
+	},
+	SL005: {
+		severity: "error",
+		title: "Empty requirement",
+		messages: { default: 'Requirement "{requirement}" has an empty body.' },
+	},
+	SL010: {
+		severity: "warning",
+		title: "Near-duplicate requirement",
+		messages: {
+			default:
+				'Requirement "{requirement}" duplicates a requirement in {others}.',
+		},
+	},
+	SL011: {
+		severity: "warning",
+		title: "Reference to archived change",
+		messages: { default: 'References archived change "{slug}".' },
+	},
+	SL012: {
+		severity: "warning",
+		title: "Tasks disconnected from specs",
+		messages: {
+			default:
+				"Task list never mentions any capability this change touches ({capabilities}).",
+		},
+	},
+	SL013: {
+		severity: "warning",
+		title: "Task completion vs archive state",
+		messages: {
+			readyToArchive: "All tasks are complete but the change is not archived.",
+			archivedIncomplete:
+				"Change is archived with incomplete tasks ({done}/{total}).",
+		},
+	},
+	SL020: {
+		severity: "warning",
+		title: "RFC 2119 misuse",
+		messages: {
+			default:
+				'Lowercase "{word}" in normative text - use uppercase RFC 2119 form.',
+		},
+	},
+	SL021: {
+		severity: "warning",
+		title: "Conflicting modality",
+		messages: { default: "Conflicting modality in one clause: {modals}." },
+	},
+	SL022: {
+		severity: "warning",
+		title: "Ambiguous term",
+		messages: {
+			default: 'Ambiguous term "{term}" - replace with a measurable bound.',
+		},
+	},
+	SL023: {
+		severity: "info",
+		title: "Unbounded quantity",
+		messages: {
+			default: 'Unbounded quantity "{term}" in a normative sentence.',
+		},
+	},
+} as const satisfies Record<string, CheckDefinition>;
+
+export type CheckId = keyof typeof CHECKS;
+
+/**
+ * SL022 base word list. Deterministic core - a future opt-in local-AI action
+ * may propose additions, but suggestions must land here (or in a user
+ * setting) explicitly, never silently at scan time.
+ */
+export const AMBIGUITY_TERMS = [
+	"fast",
+	"quickly",
+	"appropriate",
+	"reasonable",
+	"etc.",
+	"as needed",
+] as const;
+
+/** SL023 word list: quantities with no bound. */
+export const UNBOUNDED_QUANTIFIERS = ["some", "several", "many"] as const;
+
+/** Fills {placeholder} slots in a check message template. */
+export function formatCheckMessage(
+	id: CheckId,
+	variant: string,
+	params: Record<string, string> = {},
+): string {
+	const def: CheckDefinition = CHECKS[id];
+	const template = def.messages[variant] ?? variant;
+	return template.replace(/\{(\w+)\}/g, (_, key: string) =>
+		key in params ? params[key] : `{${key}}`,
+	);
+}

--- a/src/sidebar/AppSidebar.tsx
+++ b/src/sidebar/AppSidebar.tsx
@@ -2,6 +2,7 @@ import DescriptionOutlinedIcon from "@mui/icons-material/DescriptionOutlined";
 import FolderOutlinedIcon from "@mui/icons-material/FolderOutlined";
 import GridViewOutlinedIcon from "@mui/icons-material/GridViewOutlined";
 import HubOutlinedIcon from "@mui/icons-material/HubOutlined";
+import RuleIcon from "@mui/icons-material/Rule";
 import SchemaOutlinedIcon from "@mui/icons-material/SchemaOutlined";
 import TimelineOutlinedIcon from "@mui/icons-material/TimelineOutlined";
 import TrendingUpIcon from "@mui/icons-material/TrendingUp";
@@ -19,6 +20,7 @@ import {
 import { alpha } from "@mui/material/styles";
 import { type ReactNode, useMemo, useState } from "react";
 import { RepositorySwitcher } from "../repos/RepositorySwitcher";
+import { useSpecCheckResults } from "../specs/useSpecChecks";
 import {
 	type AppView,
 	DEFAULT_SETTINGS,
@@ -92,13 +94,15 @@ export function AppSidebar() {
 	const setSelectedSpec = useAppStore((s) => s.setSelectedSpec);
 	const setSelectedSchema = useAppStore((s) => s.setSelectedSchema);
 	const repos = useAppStore((s) => s.repos);
+	const specChecksEnabled = useAppStore((s) => s.settings.specChecks);
 	const activeRepo = repos.find((r) => r.id === selectedRepoId) ?? repos[0];
+	const checksCount = useSpecCheckResults(activeRepo ?? null).length;
 	const resolvedWorkflow = useMemo<ResolvedNavItem[]>(() => {
 		const counts: Partial<Record<AppView, number>> = {};
 		if (activeRepo) {
 			counts.changes = activeRepo.changes.length;
 		}
-		return workflowNav.map((item) => ({
+		const items = workflowNav.map((item) => ({
 			key: item.key,
 			label: item.label,
 			icon: item.icon,
@@ -109,7 +113,26 @@ export function AppSidebar() {
 				setView(item.id);
 			},
 		}));
-	}, [activeRepo, view, setView, setSelectedChangeKey]);
+		if (specChecksEnabled) {
+			// After Overview and Changes: analysis of what the changes contain.
+			items.splice(2, 0, {
+				key: "checks",
+				label: "Checks",
+				icon: <RuleIcon />,
+				count: checksCount > 0 ? checksCount : undefined,
+				active: view === "checks",
+				onClick: () => setView("checks"),
+			});
+		}
+		return items;
+	}, [
+		activeRepo,
+		view,
+		setView,
+		setSelectedChangeKey,
+		specChecksEnabled,
+		checksCount,
+	]);
 	// Library tabs: Specs and Schemas are special (their views render content
 	// differently from generic markdown). Everything else under openspec/ - any
 	// folder - is auto-discovered from repo.folders and surfaced as a tab.

--- a/src/sidebar/SidebarFooter.tsx
+++ b/src/sidebar/SidebarFooter.tsx
@@ -335,6 +335,30 @@ export function SidebarFooter({ collapsed = false }: Props) {
 								}
 							/>
 
+							<FormControlLabel
+								sx={{ ml: 0, alignItems: "flex-start" }}
+								control={
+									<Switch
+										checked={settings.specChecks}
+										onChange={(_, checked) => setSetting("specChecks", checked)}
+										sx={{ mt: -0.5 }}
+									/>
+								}
+								label={
+									<Box>
+										<Typography variant="body2" sx={{ fontWeight: 500 }}>
+											Spec checks
+										</Typography>
+										<Typography variant="caption" color="text.secondary">
+											Lints loaded changes for structural, consistency, and
+											language issues (missing documents, malformed EARS blocks,
+											ambiguous wording) and shows findings on each change.
+											Everything runs locally and deterministically.
+										</Typography>
+									</Box>
+								}
+							/>
+
 							<SettingRow
 								title="Tutorial"
 								caption="Replay the quick tour of SpecLens shown on first launch."

--- a/src/sidebar/SidebarFooter.tsx
+++ b/src/sidebar/SidebarFooter.tsx
@@ -335,29 +335,60 @@ export function SidebarFooter({ collapsed = false }: Props) {
 								}
 							/>
 
-							<FormControlLabel
-								sx={{ ml: 0, alignItems: "flex-start" }}
-								control={
-									<Switch
-										checked={settings.specChecks}
-										onChange={(_, checked) => setSetting("specChecks", checked)}
-										sx={{ mt: -0.5 }}
-									/>
-								}
-								label={
-									<Box>
-										<Typography variant="body2" sx={{ fontWeight: 500 }}>
-											Spec checks
-										</Typography>
-										<Typography variant="caption" color="text.secondary">
-											Lints loaded changes for structural, consistency, and
-											language issues (missing documents, malformed EARS blocks,
-											ambiguous wording) and shows findings on each change.
-											Everything runs locally and deterministically.
-										</Typography>
-									</Box>
-								}
-							/>
+							<Box>
+								<FormControlLabel
+									sx={{ ml: 0, alignItems: "flex-start" }}
+									control={
+										<Switch
+											checked={settings.specChecks}
+											onChange={(_, checked) =>
+												setSetting("specChecks", checked)
+											}
+											sx={{ mt: -0.5 }}
+										/>
+									}
+									label={
+										<Box>
+											<Typography variant="body2" sx={{ fontWeight: 500 }}>
+												Spec checks
+											</Typography>
+											<Typography variant="caption" color="text.secondary">
+												Lints loaded changes and specs for structural,
+												consistency, and language issues (missing documents,
+												malformed EARS blocks, ambiguous wording) and shows
+												findings on each change. Everything runs locally and
+												deterministically.
+											</Typography>
+										</Box>
+									}
+								/>
+								<FormControlLabel
+									sx={{ ml: 3, mt: 1, alignItems: "flex-start" }}
+									control={
+										<Switch
+											checked={settings.specChecksIncludeArchived}
+											onChange={(_, checked) =>
+												setSetting("specChecksIncludeArchived", checked)
+											}
+											disabled={!settings.specChecks}
+											size="small"
+											sx={{ mt: -0.25 }}
+										/>
+									}
+									label={
+										<Box>
+											<Typography variant="body2" sx={{ fontWeight: 500 }}>
+												Include archived changes
+											</Typography>
+											<Typography variant="caption" color="text.secondary">
+												Also lint the documents and spec deltas of archived
+												changes. Off by default - archived findings are
+												historical and can drown the live signal.
+											</Typography>
+										</Box>
+									}
+								/>
+							</Box>
 
 							<SettingRow
 								title="Tutorial"

--- a/src/sidebar/SidebarFooter.tsx
+++ b/src/sidebar/SidebarFooter.tsx
@@ -9,6 +9,7 @@ import {
 	Badge,
 	Box,
 	Button,
+	Chip,
 	Dialog,
 	DialogActions,
 	DialogContent,
@@ -349,15 +350,32 @@ export function SidebarFooter({ collapsed = false }: Props) {
 									}
 									label={
 										<Box>
-											<Typography variant="body2" sx={{ fontWeight: 500 }}>
-												Spec checks
-											</Typography>
+											<Box
+												sx={{ display: "flex", alignItems: "center", gap: 1 }}
+											>
+												<Typography variant="body2" sx={{ fontWeight: 500 }}>
+													Spec checks
+												</Typography>
+												<Chip
+													label="Beta"
+													size="small"
+													color="info"
+													variant="outlined"
+													sx={{
+														height: 18,
+														fontSize: "0.625rem",
+														fontWeight: 600,
+														"& .MuiChip-label": { px: 0.75 },
+													}}
+												/>
+											</Box>
 											<Typography variant="caption" color="text.secondary">
 												Lints loaded changes and specs for structural,
 												consistency, and language issues (missing documents,
 												malformed EARS blocks, ambiguous wording) and shows
 												findings on each change. Everything runs locally and
-												deterministically.
+												deterministically. Experimental - checks and their
+												severities may change.
 											</Typography>
 										</Box>
 									}

--- a/src/specs/ChangeViewer.tsx
+++ b/src/specs/ChangeViewer.tsx
@@ -28,6 +28,7 @@ import {
 	isChecklistArtifact,
 	type OpenSpecSchema,
 } from "../lib/schema";
+import type { SpecCheckResult } from "../lib/specChecks";
 import { countTaskCompletion } from "../lib/tasksCompletion";
 import { type TabKey, useAppStore } from "../store/useAppStore";
 import { AiDocSummaryButton } from "./AiDocSummaryButton";
@@ -35,12 +36,14 @@ import { AttributionLine } from "./AttributionLine";
 import { DocumentStatsTooltipContent } from "./DocumentStatsTooltip";
 import { MarkdownView } from "./MarkdownView";
 import { Minimap } from "./Minimap";
+import { SpecChecksBadge } from "./SpecChecksBadge";
 
 interface Props {
 	change: Change;
 	schema: OpenSpecSchema;
 	commentsOpen: boolean;
 	onToggleComments: () => void;
+	checkResults?: SpecCheckResult[];
 }
 
 function tabLabel(
@@ -61,6 +64,7 @@ export function ChangeViewer({
 	schema,
 	commentsOpen,
 	onToggleComments,
+	checkResults = [],
 }: Props) {
 	const tab = useAppStore((s) => s.activeTab);
 	const setTab = useAppStore((s) => s.setActiveTab);
@@ -303,6 +307,7 @@ export function ChangeViewer({
 							<ZoomInIcon fontSize="small" />
 						</IconButton>
 					</Tooltip>
+					<SpecChecksBadge results={checkResults} />
 					<AiDocSummaryButton
 						title={change.name}
 						kind={

--- a/src/specs/ChangeViewer.tsx
+++ b/src/specs/ChangeViewer.tsx
@@ -28,7 +28,11 @@ import {
 	isChecklistArtifact,
 	type OpenSpecSchema,
 } from "../lib/schema";
-import type { SpecCheckResult } from "../lib/specChecks";
+import {
+	countBySeverity,
+	maxSeverity,
+	type SpecCheckResult,
+} from "../lib/specChecks";
 import { countTaskCompletion } from "../lib/tasksCompletion";
 import { type TabKey, useAppStore } from "../store/useAppStore";
 import { AiDocSummaryButton } from "./AiDocSummaryButton";
@@ -157,6 +161,22 @@ export function ChangeViewer({
 		const { total, done } = countTaskCompletion(change.tasks);
 		return total > 0 && done === total;
 	}, [change.archived, change.tasks]);
+
+	// Findings with no text anchor (SL001/SL002 missing docs, SL012 task/spec
+	// drift, SL013 archive state) can't render as underlines - surface them as
+	// a banner so a badge count is never invisible in the document itself.
+	// SL013's ready-to-archive variant is skipped: the dedicated alert below
+	// already covers that state.
+	const unanchoredFindings = useMemo(
+		() =>
+			checkResults.filter(
+				(r) =>
+					!(r.snippet ?? r.heading) && !(r.id === "SL013" && !change.archived),
+			),
+		[checkResults, change.archived],
+	);
+	const unanchoredSeverity =
+		maxSeverity(countBySeverity(unanchoredFindings)) ?? "info";
 
 	const fileAuthorship = useMemo(() => {
 		if (!change.authorship) return null;
@@ -367,6 +387,37 @@ export function ChangeViewer({
 					}}
 				>
 					All tasks are complete - this change is ready to archive.
+				</Alert>
+			)}
+			{unanchoredFindings.length > 0 && (
+				<Alert
+					severity={unanchoredSeverity}
+					variant="outlined"
+					sx={{
+						mx: 4,
+						mt: 2,
+						py: 0.25,
+						"& .MuiAlert-message": { py: 0.5 },
+					}}
+				>
+					{unanchoredFindings.map((finding, i) => (
+						<Typography
+							// biome-ignore lint/suspicious/noArrayIndexKey: results are recomputed wholesale, never reordered in place
+							key={`${finding.id}-${i}`}
+							variant="body2"
+							sx={{ lineHeight: 1.6 }}
+						>
+							{finding.message}{" "}
+							<Typography
+								component="span"
+								variant="caption"
+								color="text.secondary"
+								sx={{ fontFamily: "ui-monospace, monospace" }}
+							>
+								{finding.id}
+							</Typography>
+						</Typography>
+					))}
 				</Alert>
 			)}
 			<Box

--- a/src/specs/MarkdownView.tsx
+++ b/src/specs/MarkdownView.tsx
@@ -40,14 +40,11 @@ import {
 	highlightKey,
 } from "../lib/highlight";
 import { formatRelativeTime } from "../lib/relativeTime";
-import {
-	checksByAnchorText,
-	runSpecChecks,
-	type SpecCheckResult,
-} from "../lib/specChecks";
+import { checksByAnchorText, type SpecCheckResult } from "../lib/specChecks";
 import { useCurrentDocument } from "../lib/useCurrentDocument";
 import { useAppStore } from "../store/useAppStore";
 import { useCommentsStore } from "../store/useCommentsStore";
+import { useSpecCheckResults } from "./useSpecChecks";
 
 // Lazy: mermaid is ~3 MB across its chunks and only needed when a document
 // actually contains a ```mermaid fence - keep it off the startup path.
@@ -186,18 +183,17 @@ export function MarkdownView({
 	);
 
 	// IDE-style wavy underlines for spec-check findings anchored in this
-	// document. runSpecChecks is pure and memoized on repo identity, so this
+	// document. Results are memoized on repo identity + settings, so this
 	// only recomputes when the repo reloads.
 	const repos = useAppStore((s) => s.repos);
-	const specChecksEnabled = useAppStore((s) => s.settings.specChecks);
+	const checksRepo = repos.find((r) => r.id === selectedRepoId) ?? null;
+	const checkResults = useSpecCheckResults(checksRepo);
 	const checksByAnchor = useMemo(() => {
-		if (!specChecksEnabled || !documentId) {
+		if (!checksRepo || !documentId) {
 			return new Map<string, SpecCheckResult[]>();
 		}
-		const repo = repos.find((r) => r.id === selectedRepoId);
-		if (!repo) return new Map<string, SpecCheckResult[]>();
-		return checksByAnchorText(repo, runSpecChecks(repo), documentId);
-	}, [repos, selectedRepoId, specChecksEnabled, documentId]);
+		return checksByAnchorText(checksRepo, checkResults, documentId);
+	}, [checksRepo, checkResults, documentId]);
 	const checkTargets: HighlightTarget[] = useMemo(
 		() =>
 			[...checksByAnchor.entries()].map(([text, findings]) => ({

--- a/src/specs/MarkdownView.tsx
+++ b/src/specs/MarkdownView.tsx
@@ -2,6 +2,9 @@ import { keyframes } from "@emotion/react";
 import CheckCircleIcon from "@mui/icons-material/CheckCircle";
 import CheckCircleOutlineIcon from "@mui/icons-material/CheckCircleOutlined";
 import DeleteOutlineIcon from "@mui/icons-material/DeleteOutlined";
+import ErrorOutlinedIcon from "@mui/icons-material/ErrorOutlined";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import {
 	Avatar,
 	Box,
@@ -37,6 +40,11 @@ import {
 	highlightKey,
 } from "../lib/highlight";
 import { formatRelativeTime } from "../lib/relativeTime";
+import {
+	checksByAnchorText,
+	runSpecChecks,
+	type SpecCheckResult,
+} from "../lib/specChecks";
 import { useCurrentDocument } from "../lib/useCurrentDocument";
 import { useAppStore } from "../store/useAppStore";
 import { useCommentsStore } from "../store/useCommentsStore";
@@ -177,6 +185,43 @@ export function MarkdownView({
 		[commentsForDoc],
 	);
 
+	// IDE-style wavy underlines for spec-check findings anchored in this
+	// document. runSpecChecks is pure and memoized on repo identity, so this
+	// only recomputes when the repo reloads.
+	const repos = useAppStore((s) => s.repos);
+	const specChecksEnabled = useAppStore((s) => s.settings.specChecks);
+	const checksByAnchor = useMemo(() => {
+		if (!specChecksEnabled || !documentId) {
+			return new Map<string, SpecCheckResult[]>();
+		}
+		const repo = repos.find((r) => r.id === selectedRepoId);
+		if (!repo) return new Map<string, SpecCheckResult[]>();
+		return checksByAnchorText(repo, runSpecChecks(repo), documentId);
+	}, [repos, selectedRepoId, specChecksEnabled, documentId]);
+	const checkTargets: HighlightTarget[] = useMemo(
+		() =>
+			[...checksByAnchor.entries()].map(([text, findings]) => ({
+				text,
+				occurrence: 1,
+				className: `spec-check spec-check-${findings[0].severity}`,
+			})),
+		[checksByAnchor],
+	);
+	// highlightKey → findings, for the hover diagnostics on underlined marks.
+	const checksByKey = useMemo(() => {
+		const map = new Map<string, SpecCheckResult[]>();
+		for (const [text, findings] of checksByAnchor) {
+			map.set(highlightKey({ text, occurrence: 1 }), findings);
+		}
+		return map;
+	}, [checksByAnchor]);
+	const checksByKeyRef = useRef(checksByKey);
+	checksByKeyRef.current = checksByKey;
+	const [checkHover, setCheckHover] = useState<{
+		key: string;
+		findings: SpecCheckResult[];
+	} | null>(null);
+
 	// highlightKey (text|occurrence) → the comment(s) sharing that highlight,
 	// used to resolve which comment a hovered <mark> belongs to.
 	const commentsByKey = useMemo(() => {
@@ -273,7 +318,28 @@ export function MarkdownView({
 		void source;
 		void highlightEars;
 		try {
-			const found = applyHighlights(container, highlights);
+			// Comments win key collisions with check underlines; a transient
+			// anchor is added for scroll targets that match no existing mark
+			// (check-finding jumps), so the flash below always has a mark to hit.
+			const commentKeys = new Set(highlights.map((h) => highlightKey(h)));
+			const targets = [
+				...highlights,
+				...checkTargets.filter((t) => !commentKeys.has(highlightKey(t))),
+			];
+			if (
+				scrollTarget &&
+				documentId &&
+				scrollTarget.documentId === documentId
+			) {
+				const blink = {
+					text: scrollTarget.text,
+					occurrence: scrollTarget.occurrence,
+				};
+				if (!targets.some((t) => highlightKey(t) === highlightKey(blink))) {
+					targets.push(blink);
+				}
+			}
+			const found = applyHighlights(container, targets);
 			if (documentId && selectedRepoId) {
 				const orphans: Record<string, boolean> = {};
 				for (const [id, ok] of Object.entries(found)) orphans[id] = !ok;
@@ -310,6 +376,7 @@ export function MarkdownView({
 		}
 	}, [
 		highlights,
+		checkTargets,
 		documentId,
 		selectedRepoId,
 		scrollTarget,
@@ -381,10 +448,16 @@ export function MarkdownView({
 			const mark = target?.closest<HTMLElement>("mark.user-highlight");
 			if (!mark || !container.contains(mark)) return;
 			const key = mark.dataset.highlightKey;
-			const cs = key ? commentsByKeyRef.current.get(key) : undefined;
-			if (cs && cs.length > 0 && key) {
+			if (!key) return;
+			const cs = commentsByKeyRef.current.get(key);
+			if (cs && cs.length > 0) {
 				clearHide();
 				setHover({ key, comments: cs });
+				return;
+			}
+			const findings = checksByKeyRef.current.get(key);
+			if (findings && findings.length > 0) {
+				setCheckHover({ key, findings });
 			}
 		};
 		container.addEventListener("mouseover", onOver);
@@ -416,6 +489,34 @@ export function MarkdownView({
 		document.addEventListener("mouseover", onDocOver);
 		return () => document.removeEventListener("mouseover", onDocOver);
 	}, [hover, clearHide, scheduleHide]);
+
+	// The check-diagnostics popover is read-only, so it hides as soon as the
+	// pointer leaves the underlined mark (no popover-travel grace needed).
+	useEffect(() => {
+		if (!checkHover) return;
+		const markSel = `mark.user-highlight[data-highlight-key="${CSS.escape(checkHover.key)}"]`;
+		const onDocOver = (e: MouseEvent) => {
+			const t = e.target as HTMLElement | null;
+			if (!t?.closest(markSel)) setCheckHover(null);
+		};
+		document.addEventListener("mouseover", onDocOver);
+		return () => document.removeEventListener("mouseover", onDocOver);
+	}, [checkHover]);
+
+	// Same virtual-anchor trick as the comment popover: marks are rebuilt on
+	// every applyHighlights pass, so re-query the live one at measure time.
+	const checkAnchorEl = useMemo(() => {
+		if (!checkHover) return null;
+		return {
+			getBoundingClientRect: () => {
+				const container = contentRef.current;
+				const mark = container?.querySelector<HTMLElement>(
+					`mark.user-highlight[data-highlight-key="${CSS.escape(checkHover.key)}"]`,
+				);
+				return (mark ?? container)?.getBoundingClientRect() ?? new DOMRect();
+			},
+		};
+	}, [checkHover]);
 
 	const handleSubmit = (body: string) => {
 		if (!pending || !documentId || !selectedRepoId) return;
@@ -538,6 +639,29 @@ export function MarkdownView({
 					},
 					"& mark.user-highlight.flash": {
 						animation: `${flashAnim} 0.225s ease-in-out 2`,
+					},
+					// Spec-check findings render as IDE-style wavy underlines, not
+					// comment-style fills. Severity picks the underline color.
+					"& mark.user-highlight.spec-check": {
+						bgcolor: "transparent",
+						cursor: "help",
+						px: 0,
+						textDecorationLine: "underline",
+						textDecorationStyle: "wavy",
+						textDecorationThickness: "1px",
+						textUnderlineOffset: "3px",
+					},
+					"& mark.user-highlight.spec-check:hover": {
+						bgcolor: "transparent",
+					},
+					"& mark.user-highlight.spec-check-error": {
+						textDecorationColor: (t) => t.palette.error.main,
+					},
+					"& mark.user-highlight.spec-check-warning": {
+						textDecorationColor: (t) => t.palette.warning.main,
+					},
+					"& mark.user-highlight.spec-check-info": {
+						textDecorationColor: (t) => t.palette.info.main,
 					},
 					"& .ears-kw": {
 						fontWeight: 600,
@@ -727,6 +851,67 @@ export function MarkdownView({
 									>
 										{c.body}
 									</Typography>
+								</Box>
+							))}
+						</Paper>
+					</Fade>
+				)}
+			</Popper>
+			<Popper
+				open={Boolean(checkHover)}
+				anchorEl={checkAnchorEl}
+				placement="top"
+				transition
+				sx={{ zIndex: (t) => t.zIndex.tooltip, pointerEvents: "none" }}
+				modifiers={[{ name: "offset", options: { offset: [0, 6] } }]}
+			>
+				{({ TransitionProps }) => (
+					<Fade {...TransitionProps} timeout={120}>
+						<Paper elevation={4} sx={{ maxWidth: 380, p: 0 }}>
+							{checkHover?.findings.map((finding, i) => (
+								<Box
+									// biome-ignore lint/suspicious/noArrayIndexKey: findings are recomputed wholesale, never reordered in place
+									key={`${finding.id}-${i}`}
+									sx={{
+										display: "flex",
+										alignItems: "flex-start",
+										gap: 1,
+										px: 1.5,
+										py: 1,
+										borderTop: i === 0 ? 0 : 1,
+										borderColor: "divider",
+									}}
+								>
+									{finding.severity === "error" ? (
+										<ErrorOutlinedIcon
+											color="error"
+											sx={{ fontSize: "1rem", mt: 0.25 }}
+										/>
+									) : finding.severity === "warning" ? (
+										<WarningAmberIcon
+											color="warning"
+											sx={{ fontSize: "1rem", mt: 0.25 }}
+										/>
+									) : (
+										<InfoOutlinedIcon
+											color="info"
+											sx={{ fontSize: "1rem", mt: 0.25 }}
+										/>
+									)}
+									<Box sx={{ minWidth: 0 }}>
+										<Typography variant="body2" sx={{ lineHeight: 1.45 }}>
+											{finding.message}
+										</Typography>
+										<Typography
+											variant="caption"
+											sx={{
+												color: "text.secondary",
+												fontFamily: "ui-monospace, monospace",
+											}}
+										>
+											{finding.id}
+										</Typography>
+									</Box>
 								</Box>
 							))}
 						</Paper>

--- a/src/specs/SpecCapabilityViewer.tsx
+++ b/src/specs/SpecCapabilityViewer.tsx
@@ -24,6 +24,8 @@ import { AttributionLine } from "./AttributionLine";
 import { DocumentStatsTooltipContent } from "./DocumentStatsTooltip";
 import { MarkdownView } from "./MarkdownView";
 import { Minimap } from "./Minimap";
+import { SpecChecksBadge } from "./SpecChecksBadge";
+import { useSpecCheckResults } from "./useSpecChecks";
 
 interface Props {
 	capability: string;
@@ -54,7 +56,19 @@ export function SpecCapabilityViewer({
 	const resetZoom = useAppStore((s) => s.resetZoom);
 	const storedTab = useAppStore((s) => s.specViewerTab);
 	const setStoredTab = useAppStore((s) => s.setSpecViewerTab);
+	const repos = useAppStore((s) => s.repos);
+	const selectedRepoId = useAppStore((s) => s.selectedRepoId);
 	const contentRef = useRef<HTMLDivElement | null>(null);
+
+	// Findings owned by this capability: its canonical spec plus every delta
+	// touching it (same scope as the panel's "This spec").
+	const allCheckResults = useSpecCheckResults(
+		repos.find((r) => r.id === selectedRepoId) ?? null,
+	);
+	const capabilityCheckResults = useMemo(
+		() => allCheckResults.filter((r) => r.capability === capability),
+		[allCheckResults, capability],
+	);
 
 	const defaultTab: TabValue = repoSpec
 		? "canonical"
@@ -221,6 +235,7 @@ export function SpecCapabilityViewer({
 							<ZoomInIcon fontSize="small" />
 						</IconButton>
 					</Tooltip>
+					<SpecChecksBadge results={capabilityCheckResults} />
 					<AiDocSummaryButton
 						title={
 							tab === "canonical"

--- a/src/specs/SpecChecksBadge.tsx
+++ b/src/specs/SpecChecksBadge.tsx
@@ -1,0 +1,52 @@
+import RuleIcon from "@mui/icons-material/Rule";
+import { Badge, IconButton, Tooltip } from "@mui/material";
+import {
+	countBySeverity,
+	maxSeverity,
+	type SpecCheckResult,
+} from "../lib/specChecks";
+import { useAppStore } from "../store/useAppStore";
+
+interface Props {
+	results: SpecCheckResult[];
+}
+
+/**
+ * Title-row toggle for the spec-checks panel: finding count for the current
+ * change, colored by its highest severity.
+ */
+export function SpecChecksBadge({ results }: Props) {
+	const enabled = useAppStore((s) => s.settings.specChecks);
+	const panelOpen = useAppStore((s) => s.specChecksPanelOpen);
+	const togglePanel = useAppStore((s) => s.toggleSpecChecksPanel);
+
+	if (!enabled) return null;
+
+	const counts = countBySeverity(results);
+	const top = maxSeverity(counts);
+
+	return (
+		<Tooltip
+			title={
+				counts.total > 0
+					? `Spec checks: ${counts.errors} errors, ${counts.warnings} warnings, ${counts.infos} info`
+					: "Spec checks: no findings"
+			}
+		>
+			<IconButton
+				onClick={togglePanel}
+				aria-label="Toggle spec checks panel"
+				sx={{ color: panelOpen ? "primary.main" : "text.secondary" }}
+			>
+				<Badge
+					badgeContent={counts.total}
+					color={top ?? "default"}
+					max={99}
+					invisible={counts.total === 0}
+				>
+					<RuleIcon fontSize="small" />
+				</Badge>
+			</IconButton>
+		</Tooltip>
+	);
+}

--- a/src/specs/SpecChecksBadge.tsx
+++ b/src/specs/SpecChecksBadge.tsx
@@ -1,6 +1,10 @@
+import ErrorOutlinedIcon from "@mui/icons-material/ErrorOutlined";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
 import RuleIcon from "@mui/icons-material/Rule";
-import { Badge, IconButton, Tooltip } from "@mui/material";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import { Badge, Box, IconButton, Tooltip, Typography } from "@mui/material";
 import {
+	type CheckCounts,
 	countBySeverity,
 	maxSeverity,
 	type SpecCheckResult,
@@ -9,6 +13,48 @@ import { useAppStore } from "../store/useAppStore";
 
 interface Props {
 	results: SpecCheckResult[];
+}
+
+/**
+ * Compact per-row severity indicator (error/warning/info icons + counts)
+ * used by the changes and specs listings. Renders nothing when clean.
+ */
+export function CheckSeverityCounts({ counts }: { counts: CheckCounts }) {
+	if (counts.total === 0) return null;
+	return (
+		<Tooltip
+			title={`Spec checks: ${counts.errors} errors, ${counts.warnings} warnings, ${counts.infos} info`}
+			arrow
+			placement="left"
+		>
+			<Box sx={{ display: "flex", alignItems: "center", gap: 0.75 }}>
+				{counts.errors > 0 && (
+					<Box sx={{ display: "flex", alignItems: "center", gap: 0.25 }}>
+						<ErrorOutlinedIcon color="error" sx={{ fontSize: 14 }} />
+						<Typography variant="caption" color="error">
+							{counts.errors}
+						</Typography>
+					</Box>
+				)}
+				{counts.warnings > 0 && (
+					<Box sx={{ display: "flex", alignItems: "center", gap: 0.25 }}>
+						<WarningAmberIcon color="warning" sx={{ fontSize: 14 }} />
+						<Typography variant="caption" sx={{ color: "warning.main" }}>
+							{counts.warnings}
+						</Typography>
+					</Box>
+				)}
+				{counts.infos > 0 && (
+					<Box sx={{ display: "flex", alignItems: "center", gap: 0.25 }}>
+						<InfoOutlinedIcon color="info" sx={{ fontSize: 14 }} />
+						<Typography variant="caption" sx={{ color: "info.main" }}>
+							{counts.infos}
+						</Typography>
+					</Box>
+				)}
+			</Box>
+		</Tooltip>
+	);
 }
 
 /**

--- a/src/specs/SpecChecksPanel.tsx
+++ b/src/specs/SpecChecksPanel.tsx
@@ -1,0 +1,214 @@
+import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
+import CloseIcon from "@mui/icons-material/Close";
+import ErrorOutlinedIcon from "@mui/icons-material/ErrorOutlined";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import {
+	Box,
+	IconButton,
+	List,
+	ListItemButton,
+	ListItemIcon,
+	ListItemText,
+	ListSubheader,
+	Tooltip,
+	Typography,
+} from "@mui/material";
+import { useMemo } from "react";
+import {
+	type CheckSeverity,
+	changeKeyOf,
+	countBySeverity,
+	runSpecChecks,
+	type SpecCheckResult,
+} from "../lib/specChecks";
+import { useAppStore } from "../store/useAppStore";
+import { jumpToFinding } from "./specCheckJump";
+
+const SEVERITY_ICON: Record<CheckSeverity, React.ReactNode> = {
+	error: <ErrorOutlinedIcon fontSize="small" color="error" />,
+	warning: <WarningAmberIcon fontSize="small" color="warning" />,
+	info: <InfoOutlinedIcon fontSize="small" color="info" />,
+};
+
+interface Group {
+	changeKey: string;
+	changeName: string;
+	results: SpecCheckResult[];
+}
+
+/**
+ * IDE-style "Problems" panel: all spec-check findings for the active repo,
+ * grouped by change, docked on the right like the comments panel. Clicking a
+ * finding navigates to the change/tab and blink-highlights the offending text
+ * via the scrollTarget mechanism comment jumps use.
+ */
+export function SpecChecksPanel() {
+	const open = useAppStore((s) => s.specChecksPanelOpen);
+	const setOpen = useAppStore((s) => s.setSpecChecksPanelOpen);
+	const repos = useAppStore((s) => s.repos);
+	const selectedRepoId = useAppStore((s) => s.selectedRepoId);
+	const enabled = useAppStore((s) => s.settings.specChecks);
+	const panelWidth = useAppStore((s) => s.settings.commentsPanelWidth);
+	const repo = repos.find((r) => r.id === selectedRepoId) ?? null;
+
+	const results = useMemo(
+		() => (repo && enabled ? runSpecChecks(repo) : []),
+		[repo, enabled],
+	);
+
+	const groups = useMemo(() => {
+		const byKey = new Map<string, Group>();
+		for (const result of results) {
+			let group = byKey.get(result.changeKey);
+			if (!group) {
+				const change = repo?.changes.find(
+					(c) => changeKeyOf(c) === result.changeKey,
+				);
+				group = {
+					changeKey: result.changeKey,
+					changeName: change?.name ?? result.changeKey,
+					results: [],
+				};
+				byKey.set(result.changeKey, group);
+			}
+			group.results.push(result);
+		}
+		return [...byKey.values()].sort((a, b) =>
+			a.changeName.localeCompare(b.changeName),
+		);
+	}, [results, repo]);
+
+	const counts = countBySeverity(results);
+
+	const handleJump = (result: SpecCheckResult) => {
+		if (repo) jumpToFinding(repo, result);
+	};
+
+	return (
+		<Box
+			sx={{
+				position: "relative",
+				width: open ? panelWidth : 0,
+				flexShrink: 0,
+				transition: "width 200ms ease-in-out",
+				borderLeft: open ? 1 : 0,
+				borderColor: "divider",
+				bgcolor: "background.paper",
+				display: "flex",
+				flexDirection: "column",
+				overflow: "hidden",
+				pointerEvents: open ? "auto" : "none",
+			}}
+		>
+			<Box
+				sx={{
+					display: "flex",
+					alignItems: "center",
+					px: 1.5,
+					py: 1,
+					borderBottom: 1,
+					borderColor: "divider",
+					flexShrink: 0,
+					gap: 0.5,
+				}}
+			>
+				<Typography variant="subtitle2" sx={{ fontWeight: 600, flex: 1 }}>
+					Spec checks
+				</Typography>
+				<Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
+					{counts.errors > 0 && `${counts.errors} errors`}
+					{counts.errors > 0 && counts.warnings + counts.infos > 0 && " · "}
+					{counts.warnings > 0 && `${counts.warnings} warnings`}
+					{counts.warnings > 0 && counts.infos > 0 && " · "}
+					{counts.infos > 0 && `${counts.infos} info`}
+				</Typography>
+				<Tooltip title="Close">
+					<IconButton
+						size="small"
+						onClick={() => setOpen(false)}
+						aria-label="Close spec checks panel"
+						sx={{ color: "text.secondary" }}
+					>
+						<CloseIcon fontSize="small" />
+					</IconButton>
+				</Tooltip>
+			</Box>
+			<Box sx={{ flex: 1, overflowY: "auto" }}>
+				{results.length === 0 ? (
+					<Box
+						sx={{
+							display: "flex",
+							flexDirection: "column",
+							alignItems: "center",
+							gap: 1,
+							py: 6,
+							px: 2,
+							color: "text.secondary",
+						}}
+					>
+						<CheckCircleOutlinedIcon color="success" />
+						<Typography variant="body2" sx={{ textAlign: "center" }}>
+							{enabled
+								? "No findings - all checks pass for this repository."
+								: "Spec checks are disabled in Settings."}
+						</Typography>
+					</Box>
+				) : (
+					<List dense disablePadding>
+						{groups.map((group) => (
+							<Box key={group.changeKey}>
+								<ListSubheader
+									sx={{
+										lineHeight: 2.2,
+										bgcolor: "background.default",
+										borderBottom: 1,
+										borderColor: "divider",
+										fontWeight: 600,
+									}}
+								>
+									{group.changeName}
+									<Typography
+										component="span"
+										variant="caption"
+										color="text.secondary"
+										sx={{ ml: 1 }}
+									>
+										{group.results.length}
+									</Typography>
+								</ListSubheader>
+								{group.results.map((result, i) => (
+									<ListItemButton
+										// biome-ignore lint/suspicious/noArrayIndexKey: results are recomputed wholesale, never reordered in place
+										key={`${result.id}-${i}`}
+										onClick={() => handleJump(result)}
+										sx={{ alignItems: "flex-start", gap: 1, py: 0.75 }}
+									>
+										<ListItemIcon sx={{ minWidth: 24, mt: 0.5 }}>
+											{SEVERITY_ICON[result.severity]}
+										</ListItemIcon>
+										<ListItemText
+											primary={result.message}
+											secondary={[result.id, result.tab, result.heading]
+												.filter(Boolean)
+												.join(" · ")}
+											slotProps={{
+												primary: { sx: { fontSize: "0.8125rem" } },
+												secondary: {
+													sx: {
+														fontSize: "0.6875rem",
+														fontFamily: "ui-monospace, monospace",
+													},
+												},
+											}}
+										/>
+									</ListItemButton>
+								))}
+							</Box>
+						))}
+					</List>
+				)}
+			</Box>
+		</Box>
+	);
+}

--- a/src/specs/SpecChecksPanel.tsx
+++ b/src/specs/SpecChecksPanel.tsx
@@ -11,19 +11,30 @@ import {
 	ListItemIcon,
 	ListItemText,
 	ListSubheader,
+	ToggleButton,
+	ToggleButtonGroup,
 	Tooltip,
 	Typography,
 } from "@mui/material";
-import { useMemo } from "react";
+import { alpha } from "@mui/material/styles";
+import { useMemo, useState } from "react";
 import {
 	type CheckSeverity,
 	changeKeyOf,
 	countBySeverity,
-	runSpecChecks,
 	type SpecCheckResult,
 } from "../lib/specChecks";
 import { useAppStore } from "../store/useAppStore";
 import { jumpToFinding } from "./specCheckJump";
+import { useSpecCheckResults } from "./useSpecChecks";
+
+const MIN_WIDTH = 300;
+const MAX_WIDTH = 640;
+
+// Views where findings live (documents + the checks analysis view). On any
+// other view the panel hides; the open state survives, so it reappears when
+// the user returns - same idiom as the AI panel on canvas views.
+const CHECKS_VIEWS = new Set(["changes", "specs", "checks"]);
 
 const SEVERITY_ICON: Record<CheckSeverity, React.ReactNode> = {
 	error: <ErrorOutlinedIcon fontSize="small" color="error" />,
@@ -37,49 +48,118 @@ interface Group {
 	results: SpecCheckResult[];
 }
 
+/** What the panel scopes to when the user is inside a change or a spec. */
+interface ScopeContext {
+	label: string;
+	matches: (result: SpecCheckResult) => boolean;
+}
+
 /**
- * IDE-style "Problems" panel: all spec-check findings for the active repo,
- * grouped by change, docked on the right like the comments panel. Clicking a
- * finding navigates to the change/tab and blink-highlights the offending text
- * via the scrollTarget mechanism comment jumps use.
+ * IDE-style "Problems" panel: spec-check findings for the active repo,
+ * grouped by change, docked on the right like the comments panel and
+ * drag-resizable like the AI panel. While a change or capability spec is
+ * open, the panel scopes to its findings (toggleable back to all). Clicking
+ * a finding navigates and blink-highlights the offending text.
  */
 export function SpecChecksPanel() {
-	const open = useAppStore((s) => s.specChecksPanelOpen);
+	const panelOpen = useAppStore((s) => s.specChecksPanelOpen);
 	const setOpen = useAppStore((s) => s.setSpecChecksPanelOpen);
 	const repos = useAppStore((s) => s.repos);
 	const selectedRepoId = useAppStore((s) => s.selectedRepoId);
 	const enabled = useAppStore((s) => s.settings.specChecks);
-	const panelWidth = useAppStore((s) => s.settings.commentsPanelWidth);
+	const panelWidth = useAppStore((s) => s.settings.checksPanelWidth);
+	const view = useAppStore((s) => s.view);
+	const selectedChangeKey = useAppStore((s) => s.selectedChangeKey);
+	const selectedSpec = useAppStore((s) => s.selectedSpec);
+	const [showAll, setShowAll] = useState(false);
+	const [resizing, setResizing] = useState(false);
+
+	const open = panelOpen && CHECKS_VIEWS.has(view);
 	const repo = repos.find((r) => r.id === selectedRepoId) ?? null;
 
-	const results = useMemo(
-		() => (repo && enabled ? runSpecChecks(repo) : []),
-		[repo, enabled],
+	const results = useSpecCheckResults(repo);
+
+	// Scope follows what the user is reading. "This spec" covers the
+	// capability's canonical spec and every delta touching it.
+	const context: ScopeContext | null = useMemo(() => {
+		if (view === "changes" && selectedChangeKey) {
+			return {
+				label: "This change",
+				matches: (r) => r.changeKey === selectedChangeKey,
+			};
+		}
+		if (view === "specs" && selectedSpec) {
+			return {
+				label: "This spec",
+				matches: (r) => r.capability === selectedSpec,
+			};
+		}
+		return null;
+	}, [view, selectedChangeKey, selectedSpec]);
+
+	const scoped = context !== null && !showAll;
+	const visible = useMemo(
+		() => (scoped && context ? results.filter(context.matches) : results),
+		[results, scoped, context],
 	);
 
 	const groups = useMemo(() => {
 		const byKey = new Map<string, Group>();
-		for (const result of results) {
-			let group = byKey.get(result.changeKey);
+		for (const result of visible) {
+			// Canonical-spec findings have no owning change; group per capability.
+			const groupKey = result.changeKey ?? `spec:${result.capability}`;
+			let group = byKey.get(groupKey);
 			if (!group) {
-				const change = repo?.changes.find(
-					(c) => changeKeyOf(c) === result.changeKey,
-				);
+				const change = result.changeKey
+					? repo?.changes.find((c) => changeKeyOf(c) === result.changeKey)
+					: undefined;
 				group = {
-					changeKey: result.changeKey,
-					changeName: change?.name ?? result.changeKey,
+					changeKey: groupKey,
+					changeName: result.changeKey
+						? (change?.name ?? result.changeKey)
+						: `${result.capability} (spec)`,
 					results: [],
 				};
-				byKey.set(result.changeKey, group);
+				byKey.set(groupKey, group);
 			}
 			group.results.push(result);
 		}
 		return [...byKey.values()].sort((a, b) =>
 			a.changeName.localeCompare(b.changeName),
 		);
-	}, [results, repo]);
+	}, [visible, repo]);
 
-	const counts = countBySeverity(results);
+	const counts = countBySeverity(visible);
+
+	// Same drag idiom as the AI panel: pointer capture, width written straight
+	// to the persisted setting, no transition while dragging.
+	const handleResizeStart = (e: React.PointerEvent<HTMLElement>) => {
+		e.preventDefault();
+		const startX = e.clientX;
+		const startWidth = useAppStore.getState().settings.checksPanelWidth;
+		const handle = e.currentTarget;
+		handle.setPointerCapture(e.pointerId);
+		setResizing(true);
+		const onMove = (ev: PointerEvent) => {
+			// Panel sits on the right, so dragging left grows it.
+			const w = Math.round(
+				Math.min(
+					MAX_WIDTH,
+					Math.max(MIN_WIDTH, startWidth + startX - ev.clientX),
+				),
+			);
+			useAppStore.getState().setSetting("checksPanelWidth", w);
+		};
+		const onUp = () => {
+			setResizing(false);
+			handle.removeEventListener("pointermove", onMove);
+			handle.removeEventListener("pointerup", onUp);
+			handle.removeEventListener("pointercancel", onUp);
+		};
+		handle.addEventListener("pointermove", onMove);
+		handle.addEventListener("pointerup", onUp);
+		handle.addEventListener("pointercancel", onUp);
+	};
 
 	const handleJump = (result: SpecCheckResult) => {
 		if (repo) jumpToFinding(repo, result);
@@ -91,7 +171,7 @@ export function SpecChecksPanel() {
 				position: "relative",
 				width: open ? panelWidth : 0,
 				flexShrink: 0,
-				transition: "width 200ms ease-in-out",
+				transition: resizing ? "none" : "width 200ms ease-in-out",
 				borderLeft: open ? 1 : 0,
 				borderColor: "divider",
 				bgcolor: "background.paper",
@@ -101,6 +181,31 @@ export function SpecChecksPanel() {
 				pointerEvents: open ? "auto" : "none",
 			}}
 		>
+			{open && (
+				<Box
+					onPointerDown={handleResizeStart}
+					onDoubleClick={() =>
+						useAppStore.getState().setSetting("checksPanelWidth", 380)
+					}
+					aria-label="Resize spec checks panel"
+					sx={{
+						position: "absolute",
+						top: 0,
+						left: 0,
+						bottom: 0,
+						width: 5,
+						cursor: "col-resize",
+						zIndex: 1,
+						bgcolor: resizing
+							? (t) => alpha(t.palette.primary.main, 0.3)
+							: "transparent",
+						transition: "background-color 150ms",
+						"&:hover": {
+							bgcolor: (t) => alpha(t.palette.primary.main, 0.2),
+						},
+					}}
+				/>
+			)}
 			<Box
 				sx={{
 					display: "flex",
@@ -110,19 +215,31 @@ export function SpecChecksPanel() {
 					borderBottom: 1,
 					borderColor: "divider",
 					flexShrink: 0,
-					gap: 0.5,
+					gap: 1,
 				}}
 			>
 				<Typography variant="subtitle2" sx={{ fontWeight: 600, flex: 1 }}>
 					Spec checks
 				</Typography>
-				<Typography variant="caption" color="text.secondary" sx={{ mr: 0.5 }}>
-					{counts.errors > 0 && `${counts.errors} errors`}
-					{counts.errors > 0 && counts.warnings + counts.infos > 0 && " · "}
-					{counts.warnings > 0 && `${counts.warnings} warnings`}
-					{counts.warnings > 0 && counts.infos > 0 && " · "}
-					{counts.infos > 0 && `${counts.infos} info`}
-				</Typography>
+				{context && (
+					<ToggleButtonGroup
+						size="small"
+						exclusive
+						value={scoped ? "scoped" : "all"}
+						onChange={(_, v) => v && setShowAll(v === "all")}
+						sx={{
+							"& .MuiToggleButton-root": {
+								py: 0,
+								px: 1,
+								textTransform: "none",
+								fontSize: "0.6875rem",
+							},
+						}}
+					>
+						<ToggleButton value="scoped">{context.label}</ToggleButton>
+						<ToggleButton value="all">All</ToggleButton>
+					</ToggleButtonGroup>
+				)}
 				<Tooltip title="Close">
 					<IconButton
 						size="small"
@@ -134,8 +251,22 @@ export function SpecChecksPanel() {
 					</IconButton>
 				</Tooltip>
 			</Box>
+			<Box
+				sx={{
+					px: 1.5,
+					py: 0.5,
+					borderBottom: 1,
+					borderColor: "divider",
+					flexShrink: 0,
+				}}
+			>
+				<Typography variant="caption" color="text.secondary">
+					{counts.errors} errors · {counts.warnings} warnings · {counts.infos}{" "}
+					info
+				</Typography>
+			</Box>
 			<Box sx={{ flex: 1, overflowY: "auto" }}>
-				{results.length === 0 ? (
+				{visible.length === 0 ? (
 					<Box
 						sx={{
 							display: "flex",
@@ -149,10 +280,18 @@ export function SpecChecksPanel() {
 					>
 						<CheckCircleOutlinedIcon color="success" />
 						<Typography variant="body2" sx={{ textAlign: "center" }}>
-							{enabled
-								? "No findings - all checks pass for this repository."
-								: "Spec checks are disabled in Settings."}
+							{!enabled
+								? "Spec checks are disabled in Settings."
+								: scoped && context
+									? `No findings for ${context.label.toLowerCase()}.`
+									: "No findings - all checks pass for this repository."}
 						</Typography>
+						{scoped && context && results.length > 0 && (
+							<Typography variant="caption" sx={{ textAlign: "center" }}>
+								{results.length} finding{results.length === 1 ? "" : "s"}{" "}
+								elsewhere in the repository - switch to "All".
+							</Typography>
+						)}
 					</Box>
 				) : (
 					<List dense disablePadding>

--- a/src/specs/specCheckJump.ts
+++ b/src/specs/specCheckJump.ts
@@ -7,12 +7,30 @@ import {
 import { useAppStore } from "../store/useAppStore";
 
 /**
- * Navigates to a spec-check finding: changes view, selects the change/tab
- * (and file for multi-file tabs), then blink-highlights the offending text
- * via the scrollTarget mechanism. Shared by the checks panel and Overview.
+ * Navigates to a spec-check finding and blink-highlights the offending text
+ * via the scrollTarget mechanism. Change findings open the change viewer
+ * (selecting tab + file); canonical-spec findings open the Specs view on the
+ * capability's canonical document. Shared by the checks panel and Overview.
  */
 export function jumpToFinding(repo: Repo, result: SpecCheckResult): void {
 	const store = useAppStore.getState();
+	const text = result.snippet ?? result.heading;
+
+	if (result.changeKey === null) {
+		if (!result.capability) return;
+		store.setView("specs");
+		store.setSelectedSpec(result.capability);
+		store.setSpecViewerTab("canonical");
+		if (text) {
+			store.setScrollTarget({
+				documentId: `spec:${result.capability}`,
+				text,
+				occurrence: 1,
+			});
+		}
+		return;
+	}
+
 	const change = repo.changes.find((c) => changeKeyOf(c) === result.changeKey);
 	store.setView("changes");
 	store.setSelectedChangeKey(result.changeKey);
@@ -22,7 +40,6 @@ export function jumpToFinding(repo: Repo, result: SpecCheckResult): void {
 	if (result.file && tabFiles.length > 1) {
 		store.setSelectedFile(change.slug, result.tab, result.file);
 	}
-	const text = result.snippet ?? result.heading;
 	const documentId = findingDocumentId(change, result);
 	if (text && documentId) {
 		store.setScrollTarget({ documentId, text, occurrence: 1 });

--- a/src/specs/specCheckJump.ts
+++ b/src/specs/specCheckJump.ts
@@ -1,0 +1,30 @@
+import type { Repo } from "../lib/repoLoader";
+import {
+	changeKeyOf,
+	findingDocumentId,
+	type SpecCheckResult,
+} from "../lib/specChecks";
+import { useAppStore } from "../store/useAppStore";
+
+/**
+ * Navigates to a spec-check finding: changes view, selects the change/tab
+ * (and file for multi-file tabs), then blink-highlights the offending text
+ * via the scrollTarget mechanism. Shared by the checks panel and Overview.
+ */
+export function jumpToFinding(repo: Repo, result: SpecCheckResult): void {
+	const store = useAppStore.getState();
+	const change = repo.changes.find((c) => changeKeyOf(c) === result.changeKey);
+	store.setView("changes");
+	store.setSelectedChangeKey(result.changeKey);
+	if (!change || !result.tab) return;
+	store.setActiveTab(result.tab);
+	const tabFiles = change.documentFiles[result.tab] ?? [];
+	if (result.file && tabFiles.length > 1) {
+		store.setSelectedFile(change.slug, result.tab, result.file);
+	}
+	const text = result.snippet ?? result.heading;
+	const documentId = findingDocumentId(change, result);
+	if (text && documentId) {
+		store.setScrollTarget({ documentId, text, occurrence: 1 });
+	}
+}

--- a/src/specs/useSpecChecks.ts
+++ b/src/specs/useSpecChecks.ts
@@ -1,0 +1,21 @@
+import { useMemo } from "react";
+import type { Repo } from "../lib/repoLoader";
+import { runSpecChecks, type SpecCheckResult } from "../lib/specChecks";
+import { useAppStore } from "../store/useAppStore";
+
+/**
+ * Settings-aware spec-check results for a repo: empty when the feature is
+ * off, archived changes included per settings.specChecksIncludeArchived.
+ * The single place UI components get findings from, so the settings wiring
+ * can't drift between surfaces.
+ */
+export function useSpecCheckResults(repo: Repo | null): SpecCheckResult[] {
+	const enabled = useAppStore((s) => s.settings.specChecks);
+	const includeArchived = useAppStore(
+		(s) => s.settings.specChecksIncludeArchived,
+	);
+	return useMemo(
+		() => (repo && enabled ? runSpecChecks(repo, { includeArchived }) : []),
+		[repo, enabled, includeArchived],
+	);
+}

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -36,11 +36,16 @@ export interface AppSettings {
 	sidebarWidth: number;
 	/** Width of the AI summary side panel in px (drag-resizable). */
 	aiPanelWidth: number;
+	/** Width of the spec-checks results panel in px (drag-resizable). */
+	checksPanelWidth: number;
 	/** Daily new-version check against the GitHub releases API on startup. */
 	updateCheck: boolean;
 	/** Deterministic spec lint checks (badge on changes + results list).
 	 * On by default; can be disabled from Settings → General. */
 	specChecks: boolean;
+	/** Also lint archived changes' documents and deltas. Off by default -
+	 * archived findings are historical and drown live signal. */
+	specChecksIncludeArchived: boolean;
 	/** Local AI features (model download + on-device inference). On by
 	 * default - the UI shows, but nothing downloads or runs until the user
 	 * explicitly fetches a model, so the no-network promise holds. */
@@ -56,8 +61,10 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	commentsPanelWidth: 340,
 	sidebarWidth: 240,
 	aiPanelWidth: 380,
+	checksPanelWidth: 380,
 	updateCheck: true,
 	specChecks: true,
+	specChecksIncludeArchived: false,
 	aiEnabled: true,
 	aiModel: DEFAULT_AI_MODEL_ID,
 };
@@ -106,6 +113,12 @@ export function sanitizeSettings(raw: unknown): AppSettings {
 			r.aiPanelWidth <= 640
 				? r.aiPanelWidth
 				: DEFAULT_SETTINGS.aiPanelWidth,
+		checksPanelWidth:
+			typeof r.checksPanelWidth === "number" &&
+			r.checksPanelWidth >= 300 &&
+			r.checksPanelWidth <= 640
+				? r.checksPanelWidth
+				: DEFAULT_SETTINGS.checksPanelWidth,
 		aiEnabled:
 			typeof r.aiEnabled === "boolean"
 				? r.aiEnabled
@@ -118,6 +131,10 @@ export function sanitizeSettings(raw: unknown): AppSettings {
 			typeof r.specChecks === "boolean"
 				? r.specChecks
 				: DEFAULT_SETTINGS.specChecks,
+		specChecksIncludeArchived:
+			typeof r.specChecksIncludeArchived === "boolean"
+				? r.specChecksIncludeArchived
+				: DEFAULT_SETTINGS.specChecksIncludeArchived,
 		// Custom (imported) model ids are not in the registry, so any safe file
 		// stem is accepted - a persisted custom selection must survive restarts.
 		aiModel: isValidAiModelId(r.aiModel) ? r.aiModel : DEFAULT_SETTINGS.aiModel,
@@ -128,6 +145,7 @@ export type AppView =
 	| "overview"
 	| "specs"
 	| "changes"
+	| "checks"
 	| "flow"
 	| "graph"
 	| "timeline"

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -38,6 +38,9 @@ export interface AppSettings {
 	aiPanelWidth: number;
 	/** Daily new-version check against the GitHub releases API on startup. */
 	updateCheck: boolean;
+	/** Deterministic spec lint checks (badge on changes + results list).
+	 * Off by default - opt-in from Settings → General. */
+	specChecks: boolean;
 	/** Local AI features (model download + on-device inference). On by
 	 * default - the UI shows, but nothing downloads or runs until the user
 	 * explicitly fetches a model, so the no-network promise holds. */
@@ -54,6 +57,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	sidebarWidth: 240,
 	aiPanelWidth: 380,
 	updateCheck: true,
+	specChecks: false,
 	aiEnabled: true,
 	aiModel: DEFAULT_AI_MODEL_ID,
 };
@@ -110,6 +114,10 @@ export function sanitizeSettings(raw: unknown): AppSettings {
 			typeof r.updateCheck === "boolean"
 				? r.updateCheck
 				: DEFAULT_SETTINGS.updateCheck,
+		specChecks:
+			typeof r.specChecks === "boolean"
+				? r.specChecks
+				: DEFAULT_SETTINGS.specChecks,
 		// Custom (imported) model ids are not in the registry, so any safe file
 		// stem is accepted - a persisted custom selection must survive restarts.
 		aiModel: isValidAiModelId(r.aiModel) ? r.aiModel : DEFAULT_SETTINGS.aiModel,
@@ -208,6 +216,11 @@ interface AppState {
 
 	scrollTarget: ScrollTarget | null;
 	setScrollTarget: (target: ScrollTarget | null) => void;
+
+	/** Right-side spec-check results panel (session-only, not persisted). */
+	specChecksPanelOpen: boolean;
+	setSpecChecksPanelOpen: (open: boolean) => void;
+	toggleSpecChecksPanel: () => void;
 
 	currentDocumentId: string | null;
 	setCurrentDocument: (id: string | null) => void;
@@ -533,6 +546,11 @@ export const useAppStore = create<AppState>()(
 
 		scrollTarget: null,
 		setScrollTarget: (target) => set({ scrollTarget: target }),
+
+		specChecksPanelOpen: false,
+		setSpecChecksPanelOpen: (open) => set({ specChecksPanelOpen: open }),
+		toggleSpecChecksPanel: () =>
+			set((state) => ({ specChecksPanelOpen: !state.specChecksPanelOpen })),
 
 		currentDocumentId: null,
 		setCurrentDocument: (id) => set({ currentDocumentId: id }),

--- a/src/store/useAppStore.ts
+++ b/src/store/useAppStore.ts
@@ -39,7 +39,7 @@ export interface AppSettings {
 	/** Daily new-version check against the GitHub releases API on startup. */
 	updateCheck: boolean;
 	/** Deterministic spec lint checks (badge on changes + results list).
-	 * Off by default - opt-in from Settings → General. */
+	 * On by default; can be disabled from Settings → General. */
 	specChecks: boolean;
 	/** Local AI features (model download + on-device inference). On by
 	 * default - the UI shows, but nothing downloads or runs until the user
@@ -57,7 +57,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 	sidebarWidth: 240,
 	aiPanelWidth: 380,
 	updateCheck: true,
-	specChecks: false,
+	specChecks: true,
 	aiEnabled: true,
 	aiModel: DEFAULT_AI_MODEL_ID,
 };

--- a/src/views/Breadcrumbs.tsx
+++ b/src/views/Breadcrumbs.tsx
@@ -14,6 +14,7 @@ const titles: Record<AppView, string> = {
 	overview: "Overview",
 	specs: "Specs",
 	changes: "Changes",
+	checks: "Checks",
 	flow: "Flow",
 	graph: "Graph",
 	timeline: "Timeline",

--- a/src/views/ChangesView.tsx
+++ b/src/views/ChangesView.tsx
@@ -1,3 +1,6 @@
+import ErrorOutlinedIcon from "@mui/icons-material/ErrorOutlined";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import {
 	Box,
 	ButtonBase,
@@ -16,6 +19,13 @@ import {
 } from "../lib/relativeTime";
 import type { Change, Repo } from "../lib/repoLoader";
 import { DEFAULT_SCHEMA } from "../lib/schema";
+import {
+	checksForChange,
+	countBySeverity,
+	maxSeverity,
+	runSpecChecks,
+	type SpecCheckResult,
+} from "../lib/specChecks";
 import { countTaskCompletion } from "../lib/tasksCompletion";
 import { ChangeViewer } from "../specs/ChangeViewer";
 import { useAppStore } from "../store/useAppStore";
@@ -49,10 +59,27 @@ export function ChangesView({ repo, commentsOpen, onToggleComments }: Props) {
 	const selectedChangeKey = useAppStore((s) => s.selectedChangeKey);
 	const setSelectedChangeKey = useAppStore((s) => s.setSelectedChangeKey);
 	const setActiveTab = useAppStore((s) => s.setActiveTab);
+	const specChecksEnabled = useAppStore((s) => s.settings.specChecks);
+	const toggleSpecChecksPanel = useAppStore((s) => s.toggleSpecChecksPanel);
 	const [filter, setFilter] = useState("");
 	const [status, setStatus] = useState<StatusFilter>("all");
 
 	const allChanges = repo?.changes ?? [];
+
+	const checkResults: SpecCheckResult[] = useMemo(
+		() => (repo && specChecksEnabled ? runSpecChecks(repo) : []),
+		[repo, specChecksEnabled],
+	);
+	const checkCounts = countBySeverity(checkResults);
+	const countsByChange = useMemo(() => {
+		const map = new Map<string, ReturnType<typeof countBySeverity>>();
+		for (const change of allChanges) {
+			const key = changeKey(change);
+			const own = checksForChange(checkResults, key);
+			if (own.length > 0) map.set(key, countBySeverity(own));
+		}
+		return map;
+	}, [checkResults, allChanges]);
 
 	const filtered = useMemo(() => {
 		const q = filter.trim().toLowerCase();
@@ -91,6 +118,7 @@ export function ChangesView({ repo, commentsOpen, onToggleComments }: Props) {
 				schema={change.schema ?? repo?.schema ?? DEFAULT_SCHEMA}
 				commentsOpen={commentsOpen}
 				onToggleComments={onToggleComments}
+				checkResults={checksForChange(checkResults, selectedChangeKey)}
 			/>
 		);
 	}
@@ -134,6 +162,22 @@ export function ChangesView({ repo, commentsOpen, onToggleComments }: Props) {
 						</ToggleButton>
 					</Tooltip>
 				</ToggleButtonGroup>
+				{checkCounts.total > 0 && (
+					<Tooltip
+						title={`Spec checks across this repository: ${checkCounts.errors} errors, ${checkCounts.warnings} warnings, ${checkCounts.infos} info. Click to open the results panel.`}
+						arrow
+					>
+						<Chip
+							label={`${checkCounts.total} check ${checkCounts.total === 1 ? "finding" : "findings"}`}
+							size="small"
+							variant="outlined"
+							clickable
+							onClick={toggleSpecChecksPanel}
+							color={maxSeverity(checkCounts) ?? "default"}
+							sx={{ fontWeight: 500 }}
+						/>
+					</Tooltip>
+				)}
 			</Box>
 			<Box sx={{ display: "flex", flexDirection: "column", gap: 1 }}>
 				{filtered.length === 0 ? (
@@ -148,6 +192,7 @@ export function ChangesView({ repo, commentsOpen, onToggleComments }: Props) {
 						const key = changeKey(change);
 						const preview = firstParagraphPreview(change.proposal);
 						const progress = progressLabel(change);
+						const rowCounts = countsByChange.get(key);
 						return (
 							<ButtonBase
 								key={key}
@@ -241,6 +286,79 @@ export function ChangesView({ repo, commentsOpen, onToggleComments }: Props) {
 											borderColor: change.archived ? "#d97706" : "success.main",
 										}}
 									/>
+									{rowCounts && (
+										<Tooltip
+											title={`Spec checks: ${rowCounts.errors} errors, ${rowCounts.warnings} warnings, ${rowCounts.infos} info`}
+											arrow
+											placement="left"
+										>
+											<Box
+												sx={{
+													display: "flex",
+													alignItems: "center",
+													gap: 0.75,
+												}}
+											>
+												{rowCounts.errors > 0 && (
+													<Box
+														sx={{
+															display: "flex",
+															alignItems: "center",
+															gap: 0.25,
+														}}
+													>
+														<ErrorOutlinedIcon
+															color="error"
+															sx={{ fontSize: 14 }}
+														/>
+														<Typography variant="caption" color="error">
+															{rowCounts.errors}
+														</Typography>
+													</Box>
+												)}
+												{rowCounts.warnings > 0 && (
+													<Box
+														sx={{
+															display: "flex",
+															alignItems: "center",
+															gap: 0.25,
+														}}
+													>
+														<WarningAmberIcon
+															color="warning"
+															sx={{ fontSize: 14 }}
+														/>
+														<Typography
+															variant="caption"
+															sx={{ color: "warning.main" }}
+														>
+															{rowCounts.warnings}
+														</Typography>
+													</Box>
+												)}
+												{rowCounts.infos > 0 && (
+													<Box
+														sx={{
+															display: "flex",
+															alignItems: "center",
+															gap: 0.25,
+														}}
+													>
+														<InfoOutlinedIcon
+															color="info"
+															sx={{ fontSize: 14 }}
+														/>
+														<Typography
+															variant="caption"
+															sx={{ color: "info.main" }}
+														>
+															{rowCounts.infos}
+														</Typography>
+													</Box>
+												)}
+											</Box>
+										</Tooltip>
+									)}
 									{progress && (
 										<Typography variant="caption" color="text.secondary">
 											{progress}

--- a/src/views/ChangesView.tsx
+++ b/src/views/ChangesView.tsx
@@ -1,6 +1,3 @@
-import ErrorOutlinedIcon from "@mui/icons-material/ErrorOutlined";
-import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
-import WarningAmberIcon from "@mui/icons-material/WarningAmber";
 import {
 	Box,
 	ButtonBase,
@@ -23,11 +20,12 @@ import {
 	checksForChange,
 	countBySeverity,
 	maxSeverity,
-	runSpecChecks,
 	type SpecCheckResult,
 } from "../lib/specChecks";
 import { countTaskCompletion } from "../lib/tasksCompletion";
 import { ChangeViewer } from "../specs/ChangeViewer";
+import { CheckSeverityCounts } from "../specs/SpecChecksBadge";
+import { useSpecCheckResults } from "../specs/useSpecChecks";
 import { useAppStore } from "../store/useAppStore";
 
 type StatusFilter = "all" | "active" | "archived" | "archived-incomplete";
@@ -59,17 +57,13 @@ export function ChangesView({ repo, commentsOpen, onToggleComments }: Props) {
 	const selectedChangeKey = useAppStore((s) => s.selectedChangeKey);
 	const setSelectedChangeKey = useAppStore((s) => s.setSelectedChangeKey);
 	const setActiveTab = useAppStore((s) => s.setActiveTab);
-	const specChecksEnabled = useAppStore((s) => s.settings.specChecks);
 	const toggleSpecChecksPanel = useAppStore((s) => s.toggleSpecChecksPanel);
 	const [filter, setFilter] = useState("");
 	const [status, setStatus] = useState<StatusFilter>("all");
 
 	const allChanges = repo?.changes ?? [];
 
-	const checkResults: SpecCheckResult[] = useMemo(
-		() => (repo && specChecksEnabled ? runSpecChecks(repo) : []),
-		[repo, specChecksEnabled],
-	);
+	const checkResults: SpecCheckResult[] = useSpecCheckResults(repo);
 	const checkCounts = countBySeverity(checkResults);
 	const countsByChange = useMemo(() => {
 		const map = new Map<string, ReturnType<typeof countBySeverity>>();
@@ -286,79 +280,7 @@ export function ChangesView({ repo, commentsOpen, onToggleComments }: Props) {
 											borderColor: change.archived ? "#d97706" : "success.main",
 										}}
 									/>
-									{rowCounts && (
-										<Tooltip
-											title={`Spec checks: ${rowCounts.errors} errors, ${rowCounts.warnings} warnings, ${rowCounts.infos} info`}
-											arrow
-											placement="left"
-										>
-											<Box
-												sx={{
-													display: "flex",
-													alignItems: "center",
-													gap: 0.75,
-												}}
-											>
-												{rowCounts.errors > 0 && (
-													<Box
-														sx={{
-															display: "flex",
-															alignItems: "center",
-															gap: 0.25,
-														}}
-													>
-														<ErrorOutlinedIcon
-															color="error"
-															sx={{ fontSize: 14 }}
-														/>
-														<Typography variant="caption" color="error">
-															{rowCounts.errors}
-														</Typography>
-													</Box>
-												)}
-												{rowCounts.warnings > 0 && (
-													<Box
-														sx={{
-															display: "flex",
-															alignItems: "center",
-															gap: 0.25,
-														}}
-													>
-														<WarningAmberIcon
-															color="warning"
-															sx={{ fontSize: 14 }}
-														/>
-														<Typography
-															variant="caption"
-															sx={{ color: "warning.main" }}
-														>
-															{rowCounts.warnings}
-														</Typography>
-													</Box>
-												)}
-												{rowCounts.infos > 0 && (
-													<Box
-														sx={{
-															display: "flex",
-															alignItems: "center",
-															gap: 0.25,
-														}}
-													>
-														<InfoOutlinedIcon
-															color="info"
-															sx={{ fontSize: 14 }}
-														/>
-														<Typography
-															variant="caption"
-															sx={{ color: "info.main" }}
-														>
-															{rowCounts.infos}
-														</Typography>
-													</Box>
-												)}
-											</Box>
-										</Tooltip>
-									)}
+									{rowCounts && <CheckSeverityCounts counts={rowCounts} />}
 									{progress && (
 										<Typography variant="caption" color="text.secondary">
 											{progress}

--- a/src/views/ChangesView.tsx
+++ b/src/views/ChangesView.tsx
@@ -64,7 +64,15 @@ export function ChangesView({ repo, commentsOpen, onToggleComments }: Props) {
 	const allChanges = repo?.changes ?? [];
 
 	const checkResults: SpecCheckResult[] = useSpecCheckResults(repo);
-	const checkCounts = countBySeverity(checkResults);
+	// The header chip must reconcile with the rows below it, so it counts only
+	// change-owned findings. Canonical-spec findings (changeKey null) live in
+	// the Specs listing and the Checks view instead; the tooltip points there.
+	const changeFindings = useMemo(
+		() => checkResults.filter((r) => r.changeKey !== null),
+		[checkResults],
+	);
+	const checkCounts = countBySeverity(changeFindings);
+	const specFindingsCount = checkResults.length - changeFindings.length;
 	const countsByChange = useMemo(() => {
 		const map = new Map<string, ReturnType<typeof countBySeverity>>();
 		for (const change of allChanges) {
@@ -158,7 +166,7 @@ export function ChangesView({ repo, commentsOpen, onToggleComments }: Props) {
 				</ToggleButtonGroup>
 				{checkCounts.total > 0 && (
 					<Tooltip
-						title={`Spec checks across this repository: ${checkCounts.errors} errors, ${checkCounts.warnings} warnings, ${checkCounts.infos} info. Click to open the results panel.`}
+						title={`Spec checks on this repository's changes: ${checkCounts.errors} errors, ${checkCounts.warnings} warnings, ${checkCounts.infos} info.${specFindingsCount > 0 ? ` ${specFindingsCount} more finding${specFindingsCount === 1 ? "" : "s"} live in capability specs - see the Specs listing or the Checks view.` : ""} Click to open the results panel.`}
 						arrow
 					>
 						<Chip

--- a/src/views/ChecksView.tsx
+++ b/src/views/ChecksView.tsx
@@ -1,0 +1,394 @@
+import CheckCircleOutlinedIcon from "@mui/icons-material/CheckCircleOutlined";
+import ChevronRightIcon from "@mui/icons-material/ChevronRight";
+import ErrorOutlinedIcon from "@mui/icons-material/ErrorOutlined";
+import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
+import InfoOutlinedIcon from "@mui/icons-material/InfoOutlined";
+import WarningAmberIcon from "@mui/icons-material/WarningAmber";
+import {
+	Box,
+	Chip,
+	Collapse,
+	List,
+	ListItemButton,
+	TextField,
+	ToggleButton,
+	ToggleButtonGroup,
+	Typography,
+} from "@mui/material";
+import { useMemo, useState } from "react";
+import type { Repo } from "../lib/repoLoader";
+import {
+	type CheckSeverity,
+	changeKeyOf,
+	countBySeverity,
+	maxSeverity,
+	type SpecCheckResult,
+} from "../lib/specChecks";
+import { CHECKS, type CheckId } from "../lib/specChecksConfig";
+import { jumpToFinding } from "../specs/specCheckJump";
+import { useSpecCheckResults } from "../specs/useSpecChecks";
+import { useAppStore } from "../store/useAppStore";
+
+type SeverityFilter = "all" | CheckSeverity;
+type GroupMode = "change" | "check";
+
+const SEVERITY_ICON: Record<CheckSeverity, React.ReactNode> = {
+	error: <ErrorOutlinedIcon color="error" sx={{ fontSize: 16 }} />,
+	warning: <WarningAmberIcon color="warning" sx={{ fontSize: 16 }} />,
+	info: <InfoOutlinedIcon color="info" sx={{ fontSize: 16 }} />,
+};
+
+interface TreeSubGroup {
+	key: string;
+	label: string;
+	results: SpecCheckResult[];
+}
+
+interface TreeTopGroup {
+	key: string;
+	label: string;
+	/** Extra caption next to the label (e.g. check title for id groups). */
+	caption: string | null;
+	results: SpecCheckResult[];
+	children: TreeSubGroup[];
+}
+
+interface Props {
+	repo: Repo | null;
+}
+
+function checkLabel(id: CheckId): string {
+	return `${id} · ${CHECKS[id].title}`;
+}
+
+/**
+ * Dedicated navigation destination for spec-check analysis: a two-level tree
+ * over every finding in the repo, groupable by change (change → check type)
+ * or by check (check type → change), filterable by severity and text. Leaf
+ * rows jump to the highlighted text in the owning document.
+ */
+export function ChecksView({ repo }: Props) {
+	const enabled = useAppStore((s) => s.settings.specChecks);
+	const [filter, setFilter] = useState("");
+	const [severity, setSeverity] = useState<SeverityFilter>("all");
+	const [mode, setMode] = useState<GroupMode>("change");
+	// Everything renders collapsed by default. An active text filter
+	// force-expands the tree so matches are never hidden behind a closed node.
+	const [expandedTop, setExpandedTop] = useState<Set<string>>(new Set());
+	const [expandedSub, setExpandedSub] = useState<Set<string>>(new Set());
+
+	const results = useSpecCheckResults(repo);
+	const counts = countBySeverity(results);
+
+	const query = filter.trim().toLowerCase();
+	const forceExpand = query !== "";
+
+	const visible = useMemo(() => {
+		return results.filter((r) => {
+			if (severity !== "all" && r.severity !== severity) return false;
+			if (!query) return true;
+			return [r.message, r.id, r.changeKey, r.capability, r.heading]
+				.filter(Boolean)
+				.some((field) => (field as string).toLowerCase().includes(query));
+		});
+	}, [results, severity, query]);
+
+	const tree = useMemo<TreeTopGroup[]>(() => {
+		const ownerKey = (r: SpecCheckResult) =>
+			r.changeKey ?? `spec:${r.capability}`;
+		const ownerLabel = (r: SpecCheckResult) => {
+			if (!r.changeKey) return `${r.capability} (spec)`;
+			const change = repo?.changes.find((c) => changeKeyOf(c) === r.changeKey);
+			return change?.name ?? r.changeKey;
+		};
+		const topKeyOf =
+			mode === "change" ? ownerKey : (r: SpecCheckResult) => r.id;
+		const subKeyOf =
+			mode === "change" ? (r: SpecCheckResult) => r.id : ownerKey;
+		const topLabelOf =
+			mode === "change" ? ownerLabel : (r: SpecCheckResult) => r.id;
+		const subLabelOf =
+			mode === "change" ? (r: SpecCheckResult) => checkLabel(r.id) : ownerLabel;
+
+		const tops = new Map<string, TreeTopGroup>();
+		for (const result of visible) {
+			const topKey = topKeyOf(result);
+			let top = tops.get(topKey);
+			if (!top) {
+				top = {
+					key: topKey,
+					label: topLabelOf(result),
+					caption: mode === "check" ? CHECKS[result.id].title : null,
+					results: [],
+					children: [],
+				};
+				tops.set(topKey, top);
+			}
+			top.results.push(result);
+			const subKey = subKeyOf(result);
+			let sub = top.children.find((c) => c.key === subKey);
+			if (!sub) {
+				sub = { key: subKey, label: subLabelOf(result), results: [] };
+				top.children.push(sub);
+			}
+			sub.results.push(result);
+		}
+		for (const top of tops.values()) {
+			top.children.sort((a, b) => a.label.localeCompare(b.label));
+		}
+		return [...tops.values()].sort((a, b) => a.label.localeCompare(b.label));
+	}, [visible, mode, repo]);
+
+	const toggleTop = (key: string) =>
+		setExpandedTop((prev) => {
+			const next = new Set(prev);
+			if (next.has(key)) next.delete(key);
+			else next.add(key);
+			return next;
+		});
+	const toggleSub = (key: string) =>
+		setExpandedSub((prev) => {
+			const next = new Set(prev);
+			if (next.has(key)) next.delete(key);
+			else next.add(key);
+			return next;
+		});
+
+	if (!enabled) {
+		return (
+			<Box sx={{ p: 4, width: "100%" }}>
+				<Typography color="text.secondary">
+					Spec checks are disabled. Enable them in Settings → General to lint
+					this repository's changes and specs.
+				</Typography>
+			</Box>
+		);
+	}
+
+	return (
+		<Box sx={{ p: 4, width: "100%" }}>
+			<Box
+				sx={{
+					display: "flex",
+					gap: 1.5,
+					alignItems: "center",
+					mb: 2,
+					flexWrap: "wrap",
+				}}
+			>
+				<TextField
+					placeholder="Filter findings..."
+					value={filter}
+					onChange={(e) => setFilter(e.target.value)}
+					size="small"
+					sx={{ flex: 1, minWidth: 220 }}
+				/>
+				<ToggleButtonGroup
+					size="small"
+					value={mode}
+					exclusive
+					onChange={(_, v) => v && setMode(v as GroupMode)}
+				>
+					<ToggleButton value="change" sx={{ textTransform: "none" }}>
+						By change
+					</ToggleButton>
+					<ToggleButton value="check" sx={{ textTransform: "none" }}>
+						By check
+					</ToggleButton>
+				</ToggleButtonGroup>
+				<ToggleButtonGroup
+					size="small"
+					value={severity}
+					exclusive
+					onChange={(_, v) => v && setSeverity(v as SeverityFilter)}
+				>
+					<ToggleButton value="all" sx={{ textTransform: "none" }}>
+						All ({counts.total})
+					</ToggleButton>
+					<ToggleButton value="error" sx={{ textTransform: "none" }}>
+						Errors ({counts.errors})
+					</ToggleButton>
+					<ToggleButton value="warning" sx={{ textTransform: "none" }}>
+						Warnings ({counts.warnings})
+					</ToggleButton>
+					<ToggleButton value="info" sx={{ textTransform: "none" }}>
+						Info ({counts.infos})
+					</ToggleButton>
+				</ToggleButtonGroup>
+			</Box>
+			{visible.length === 0 ? (
+				<Box
+					sx={{
+						display: "flex",
+						flexDirection: "column",
+						alignItems: "center",
+						gap: 1,
+						py: 8,
+						color: "text.secondary",
+					}}
+				>
+					<CheckCircleOutlinedIcon color="success" sx={{ fontSize: 32 }} />
+					<Typography color="text.secondary">
+						{results.length === 0
+							? "No findings - all checks pass for this repository."
+							: "No findings match this filter."}
+					</Typography>
+				</Box>
+			) : (
+				<List
+					disablePadding
+					sx={{
+						border: 1,
+						borderColor: "divider",
+						borderRadius: 1,
+						bgcolor: "background.paper",
+						overflow: "hidden",
+					}}
+				>
+					{tree.map((top) => {
+						const topOpen = forceExpand || expandedTop.has(top.key);
+						const topCounts = countBySeverity(top.results);
+						const topSeverity = maxSeverity(topCounts);
+						return (
+							<Box key={top.key}>
+								<ListItemButton
+									onClick={() => toggleTop(top.key)}
+									sx={{
+										py: 0.75,
+										gap: 1,
+										borderTop: 1,
+										borderColor: "divider",
+										"&:first-of-type": { borderTop: 0 },
+									}}
+								>
+									{topOpen ? (
+										<ExpandMoreIcon
+											sx={{ fontSize: 18, color: "text.secondary" }}
+										/>
+									) : (
+										<ChevronRightIcon
+											sx={{ fontSize: 18, color: "text.secondary" }}
+										/>
+									)}
+									{topSeverity && SEVERITY_ICON[topSeverity]}
+									<Typography
+										variant="body2"
+										sx={{
+											fontWeight: 600,
+											fontFamily:
+												mode === "check"
+													? "ui-monospace, monospace"
+													: undefined,
+										}}
+									>
+										{top.label}
+									</Typography>
+									{top.caption && (
+										<Typography variant="body2" color="text.secondary">
+											{top.caption}
+										</Typography>
+									)}
+									<Typography
+										variant="caption"
+										color="text.secondary"
+										sx={{ ml: "auto" }}
+									>
+										{top.results.length}
+									</Typography>
+								</ListItemButton>
+								<Collapse in={topOpen} timeout={150} unmountOnExit>
+									{top.children.map((sub) => {
+										const subNodeKey = `${top.key}/${sub.key}`;
+										const subOpen = forceExpand || expandedSub.has(subNodeKey);
+										const subCounts = countBySeverity(sub.results);
+										const subSeverity = maxSeverity(subCounts);
+										return (
+											<Box key={sub.key}>
+												<ListItemButton
+													onClick={() => toggleSub(subNodeKey)}
+													sx={{ py: 0.5, pl: 4.5, gap: 1 }}
+												>
+													{subOpen ? (
+														<ExpandMoreIcon
+															sx={{ fontSize: 16, color: "text.secondary" }}
+														/>
+													) : (
+														<ChevronRightIcon
+															sx={{ fontSize: 16, color: "text.secondary" }}
+														/>
+													)}
+													{subSeverity && SEVERITY_ICON[subSeverity]}
+													<Typography variant="body2">{sub.label}</Typography>
+													<Typography
+														variant="caption"
+														color="text.secondary"
+														sx={{ ml: "auto" }}
+													>
+														{sub.results.length}
+													</Typography>
+												</ListItemButton>
+												<Collapse in={subOpen} timeout={150} unmountOnExit>
+													{sub.results.map((result, i) => (
+														<ListItemButton
+															// biome-ignore lint/suspicious/noArrayIndexKey: results are recomputed wholesale, never reordered in place
+															key={`${result.id}-${i}`}
+															onClick={() =>
+																repo && jumpToFinding(repo, result)
+															}
+															sx={{
+																py: 0.5,
+																pl: 9,
+																pr: 2,
+																gap: 1.5,
+																alignItems: "flex-start",
+															}}
+														>
+															<Box sx={{ flex: 1, minWidth: 0 }}>
+																<Typography variant="body2">
+																	{result.message}
+																</Typography>
+																<Typography
+																	variant="caption"
+																	color="text.secondary"
+																	sx={{
+																		fontFamily: "ui-monospace, monospace",
+																	}}
+																>
+																	{[
+																		mode === "change" ? null : result.id,
+																		result.tab,
+																		result.heading,
+																	]
+																		.filter(Boolean)
+																		.join(" · ") || result.id}
+																</Typography>
+															</Box>
+															{result.capability && (
+																<Chip
+																	label={result.capability}
+																	size="small"
+																	variant="outlined"
+																	sx={{
+																		height: 20,
+																		fontSize: "0.6875rem",
+																		color: "text.secondary",
+																		borderColor: "divider",
+																		flexShrink: 0,
+																	}}
+																/>
+															)}
+														</ListItemButton>
+													))}
+												</Collapse>
+											</Box>
+										);
+									})}
+								</Collapse>
+							</Box>
+						);
+					})}
+				</List>
+			)}
+		</Box>
+	);
+}

--- a/src/views/OverviewView.tsx
+++ b/src/views/OverviewView.tsx
@@ -22,15 +22,11 @@ import {
 } from "../lib/relativeTime";
 import type { Change, DocAuthorship, Repo } from "../lib/repoLoader";
 import { artifactLabel } from "../lib/schema";
-import {
-	countBySeverity,
-	runSpecChecks,
-	type SpecCheckResult,
-} from "../lib/specChecks";
+import { countBySeverity, type SpecCheckResult } from "../lib/specChecks";
 import { countTaskCompletion } from "../lib/tasksCompletion";
 import { RepoConfigModal } from "../repos/RepoConfigModal";
 import { AiDocSummaryButton } from "../specs/AiDocSummaryButton";
-import { jumpToFinding } from "../specs/specCheckJump";
+import { useSpecCheckResults } from "../specs/useSpecChecks";
 import { seedDocSummaryCache } from "../store/useAiStore";
 import { useAppStore } from "../store/useAppStore";
 
@@ -75,14 +71,10 @@ export function OverviewView({ repo }: Props) {
 	const readingWpm = useAppStore((s) => s.settings.readingWpm);
 	const aiModel = useAppStore((s) => s.settings.aiModel);
 	const specChecksEnabled = useAppStore((s) => s.settings.specChecks);
-	const setSpecChecksPanelOpen = useAppStore((s) => s.setSpecChecksPanelOpen);
 	const signature = useAppStore((s) =>
 		repo ? (s.loadedSignatures[repo.id] ?? null) : null,
 	);
-	const checkResults: SpecCheckResult[] = useMemo(
-		() => (repo && specChecksEnabled ? runSpecChecks(repo) : []),
-		[repo, specChecksEnabled],
-	);
+	const checkResults: SpecCheckResult[] = useSpecCheckResults(repo);
 	const checkCounts = countBySeverity(checkResults);
 	const [configOpen, setConfigOpen] = useState(false);
 	const [tab, setTab] = useState<"summary" | "activity" | "changes" | "config">(
@@ -434,115 +426,6 @@ export function OverviewView({ repo }: Props) {
 							/>
 						)}
 					</Box>
-					{specChecksEnabled && checkCounts.total > 0 && (
-						<Section title="Spec checks">
-							<Box sx={{ display: "flex", gap: 1, mb: 1.5 }}>
-								{checkCounts.errors > 0 && (
-									<Chip
-										label={`${checkCounts.errors} errors`}
-										size="small"
-										color="error"
-										variant="outlined"
-									/>
-								)}
-								{checkCounts.warnings > 0 && (
-									<Chip
-										label={`${checkCounts.warnings} warnings`}
-										size="small"
-										color="warning"
-										variant="outlined"
-									/>
-								)}
-								{checkCounts.infos > 0 && (
-									<Chip
-										label={`${checkCounts.infos} info`}
-										size="small"
-										color="info"
-										variant="outlined"
-									/>
-								)}
-								<Button
-									size="small"
-									onClick={() => setSpecChecksPanelOpen(true)}
-									sx={{ ml: "auto", textTransform: "none" }}
-								>
-									View all
-								</Button>
-							</Box>
-							<Box sx={{ display: "flex", flexDirection: "column", gap: 0.25 }}>
-								{checkResults.slice(0, 5).map((finding, i) => (
-									<ButtonBase
-										// biome-ignore lint/suspicious/noArrayIndexKey: results are recomputed wholesale, never reordered in place
-										key={`${finding.id}-${i}`}
-										onClick={() => repo && jumpToFinding(repo, finding)}
-										sx={{
-											display: "flex",
-											alignItems: "center",
-											gap: 2,
-											px: 1.5,
-											py: 1,
-											borderRadius: 1,
-											textAlign: "left",
-											transition: "background-color 150ms",
-											"&:hover": { bgcolor: "action.hover" },
-										}}
-									>
-										<Chip
-											label={finding.severity}
-											size="small"
-											variant="outlined"
-											color={
-												finding.severity === "error"
-													? "error"
-													: finding.severity === "warning"
-														? "warning"
-														: "info"
-											}
-											sx={{
-												height: 18,
-												fontSize: "0.6875rem",
-												minWidth: 64,
-												fontFamily: "ui-monospace, monospace",
-											}}
-										/>
-										<Typography
-											variant="body2"
-											sx={{
-												overflow: "hidden",
-												textOverflow: "ellipsis",
-												whiteSpace: "nowrap",
-												flex: 1,
-											}}
-										>
-											{finding.message}
-										</Typography>
-										<Typography
-											variant="caption"
-											color="text.secondary"
-											sx={{
-												flexShrink: 0,
-												fontFamily: "ui-monospace, monospace",
-											}}
-										>
-											{repo?.changes.find(
-												(c) => changeKey(c) === finding.changeKey,
-											)?.name ?? finding.changeKey}{" "}
-											· {finding.id}
-										</Typography>
-									</ButtonBase>
-								))}
-								{checkCounts.total > 5 && (
-									<Typography
-										variant="caption"
-										color="text.secondary"
-										sx={{ px: 1.5, pt: 0.5 }}
-									>
-										{checkCounts.total - 5} more in the panel
-									</Typography>
-								)}
-							</Box>
-						</Section>
-					)}
 					{repo?.config?.context && (
 						<Box
 							sx={{

--- a/src/views/OverviewView.tsx
+++ b/src/views/OverviewView.tsx
@@ -22,9 +22,15 @@ import {
 } from "../lib/relativeTime";
 import type { Change, DocAuthorship, Repo } from "../lib/repoLoader";
 import { artifactLabel } from "../lib/schema";
+import {
+	countBySeverity,
+	runSpecChecks,
+	type SpecCheckResult,
+} from "../lib/specChecks";
 import { countTaskCompletion } from "../lib/tasksCompletion";
 import { RepoConfigModal } from "../repos/RepoConfigModal";
 import { AiDocSummaryButton } from "../specs/AiDocSummaryButton";
+import { jumpToFinding } from "../specs/specCheckJump";
 import { seedDocSummaryCache } from "../store/useAiStore";
 import { useAppStore } from "../store/useAppStore";
 
@@ -68,9 +74,16 @@ export function OverviewView({ repo }: Props) {
 	const setActiveTab = useAppStore((s) => s.setActiveTab);
 	const readingWpm = useAppStore((s) => s.settings.readingWpm);
 	const aiModel = useAppStore((s) => s.settings.aiModel);
+	const specChecksEnabled = useAppStore((s) => s.settings.specChecks);
+	const setSpecChecksPanelOpen = useAppStore((s) => s.setSpecChecksPanelOpen);
 	const signature = useAppStore((s) =>
 		repo ? (s.loadedSignatures[repo.id] ?? null) : null,
 	);
+	const checkResults: SpecCheckResult[] = useMemo(
+		() => (repo && specChecksEnabled ? runSpecChecks(repo) : []),
+		[repo, specChecksEnabled],
+	);
+	const checkCounts = countBySeverity(checkResults);
 	const [configOpen, setConfigOpen] = useState(false);
 	const [tab, setTab] = useState<"summary" | "activity" | "changes" | "config">(
 		"summary",
@@ -413,7 +426,123 @@ export function OverviewView({ repo }: Props) {
 							label="Total reading time"
 							help={`Estimated time to read every proposal, spec, and tasks file in this repo at ${readingWpm} words per minute.`}
 						/>
+						{specChecksEnabled && (
+							<StatCard
+								value={checkCounts.total}
+								label="Check findings"
+								help={`Spec-check lint findings across this repo: ${checkCounts.errors} errors, ${checkCounts.warnings} warnings, ${checkCounts.infos} info.`}
+							/>
+						)}
 					</Box>
+					{specChecksEnabled && checkCounts.total > 0 && (
+						<Section title="Spec checks">
+							<Box sx={{ display: "flex", gap: 1, mb: 1.5 }}>
+								{checkCounts.errors > 0 && (
+									<Chip
+										label={`${checkCounts.errors} errors`}
+										size="small"
+										color="error"
+										variant="outlined"
+									/>
+								)}
+								{checkCounts.warnings > 0 && (
+									<Chip
+										label={`${checkCounts.warnings} warnings`}
+										size="small"
+										color="warning"
+										variant="outlined"
+									/>
+								)}
+								{checkCounts.infos > 0 && (
+									<Chip
+										label={`${checkCounts.infos} info`}
+										size="small"
+										color="info"
+										variant="outlined"
+									/>
+								)}
+								<Button
+									size="small"
+									onClick={() => setSpecChecksPanelOpen(true)}
+									sx={{ ml: "auto", textTransform: "none" }}
+								>
+									View all
+								</Button>
+							</Box>
+							<Box sx={{ display: "flex", flexDirection: "column", gap: 0.25 }}>
+								{checkResults.slice(0, 5).map((finding, i) => (
+									<ButtonBase
+										// biome-ignore lint/suspicious/noArrayIndexKey: results are recomputed wholesale, never reordered in place
+										key={`${finding.id}-${i}`}
+										onClick={() => repo && jumpToFinding(repo, finding)}
+										sx={{
+											display: "flex",
+											alignItems: "center",
+											gap: 2,
+											px: 1.5,
+											py: 1,
+											borderRadius: 1,
+											textAlign: "left",
+											transition: "background-color 150ms",
+											"&:hover": { bgcolor: "action.hover" },
+										}}
+									>
+										<Chip
+											label={finding.severity}
+											size="small"
+											variant="outlined"
+											color={
+												finding.severity === "error"
+													? "error"
+													: finding.severity === "warning"
+														? "warning"
+														: "info"
+											}
+											sx={{
+												height: 18,
+												fontSize: "0.6875rem",
+												minWidth: 64,
+												fontFamily: "ui-monospace, monospace",
+											}}
+										/>
+										<Typography
+											variant="body2"
+											sx={{
+												overflow: "hidden",
+												textOverflow: "ellipsis",
+												whiteSpace: "nowrap",
+												flex: 1,
+											}}
+										>
+											{finding.message}
+										</Typography>
+										<Typography
+											variant="caption"
+											color="text.secondary"
+											sx={{
+												flexShrink: 0,
+												fontFamily: "ui-monospace, monospace",
+											}}
+										>
+											{repo?.changes.find(
+												(c) => changeKey(c) === finding.changeKey,
+											)?.name ?? finding.changeKey}{" "}
+											· {finding.id}
+										</Typography>
+									</ButtonBase>
+								))}
+								{checkCounts.total > 5 && (
+									<Typography
+										variant="caption"
+										color="text.secondary"
+										sx={{ px: 1.5, pt: 0.5 }}
+									>
+										{checkCounts.total - 5} more in the panel
+									</Typography>
+								)}
+							</Box>
+						</Section>
+					)}
 					{repo?.config?.context && (
 						<Box
 							sx={{

--- a/src/views/SpecsView.tsx
+++ b/src/views/SpecsView.tsx
@@ -17,7 +17,14 @@ import {
 	formatRelativeTime,
 } from "../lib/relativeTime";
 import type { Change, Repo, RepoSpecDoc } from "../lib/repoLoader";
+import {
+	type CheckCounts,
+	countBySeverity,
+	type SpecCheckResult,
+} from "../lib/specChecks";
 import { SpecCapabilityViewer } from "../specs/SpecCapabilityViewer";
+import { CheckSeverityCounts } from "../specs/SpecChecksBadge";
+import { useSpecCheckResults } from "../specs/useSpecChecks";
 import { useAppStore } from "../store/useAppStore";
 
 type SortMode = "name" | "changes" | "recent";
@@ -94,6 +101,22 @@ export function SpecsView({ repo, commentsOpen, onToggleComments }: Props) {
 	const setSelectedChangeKey = useAppStore((s) => s.setSelectedChangeKey);
 	const [filter, setFilter] = useState("");
 	const [sort, setSort] = useState<SortMode>("name");
+
+	const checkResults: SpecCheckResult[] = useSpecCheckResults(repo);
+	// Per-capability counts: a capability owns its canonical-spec findings and
+	// every delta finding touching it (same scope as the panel's "This spec").
+	const countsByCapability = useMemo(() => {
+		const byCap = new Map<string, SpecCheckResult[]>();
+		for (const result of checkResults) {
+			if (!result.capability) continue;
+			const group = byCap.get(result.capability) ?? [];
+			group.push(result);
+			byCap.set(result.capability, group);
+		}
+		const map = new Map<string, CheckCounts>();
+		for (const [cap, group] of byCap) map.set(cap, countBySeverity(group));
+		return map;
+	}, [checkResults]);
 
 	const openChange = (change: Change) => {
 		setSelectedChangeKey(changeKey(change));
@@ -297,6 +320,13 @@ export function SpecsView({ repo, commentsOpen, onToggleComments }: Props) {
 									minWidth: 100,
 								}}
 							>
+								{countsByCapability.has(row.capability) && (
+									<CheckSeverityCounts
+										counts={
+											countsByCapability.get(row.capability) as CheckCounts
+										}
+									/>
+								)}
 								<Typography variant="caption" color="text.secondary">
 									{row.referencingChanges.length} change
 									{row.referencingChanges.length === 1 ? "" : "s"}


### PR DESCRIPTION
Implements Feature 1 of docs/design/checks-and-claims.md: deterministic, local-only linting of OpenSpec changes and specs.

## Engine
- Pure lint engine (src/lib/specChecks.ts) with a config registry (specChecksConfig.ts) holding ids, severities, message templates, and word lists. No Tauri imports, keeping the CLI extraction path open.
- Checks: structural errors (SL001-SL005: missing docs, unknown capabilities, malformed EARS/Gherkin blocks, empty requirements), consistency warnings (SL010-SL013: cross-capability duplicates, archived references, task/spec drift, completion vs archive state), language checks (SL020-SL023: RFC 2119 misuse, conflicting modality, ambiguous terms, unbounded quantities).
- Covers active change deltas and canonical specs/<cap>/spec.md files; archived changes opt in via a setting.

## UI
- Checks navigation view: two-level tree groupable by change or by check id, severity/text filters, collapsed by default.
- Right-side results panel: drag-resizable, scopes to the open change/spec, hidden on views without checkable content. Only one right panel (comments / checks / AI) open at a time.
- IDE-style wavy underlines on offending text with hover diagnostics; clicking any finding navigates and blink-highlights it.
- Severity badges on the changes and specs listings, viewer toggles, Overview stat card.
- Settings: specChecks (on by default), specChecksIncludeArchived (off by default).

## Also included
- Fix: repo loading on large git histories - authorship now derives from a single history walk instead of one revwalk per file (a 4.5k-commit / 2.8k-spec repo dropped from 9+ minutes, unfinished, to ~4.3s). Env-gated benchmark test included.
- CLAUDE.md and roadmap synced; design doc committed with implementation notes.

90 Vitest + 24 cargo tests pass.