### PR TITLE
chore: release v1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0](https://github.com/dansreis/speclens/compare/v1.1.3...v1.2.0) - 2026-07-16
+
+- **Spec checks (beta)** - SpecLens now lints changes and specs locally and deterministically: missing documents, malformed EARS/Gherkin blocks, empty or duplicated requirements, RFC 2119 misuse, ambiguous wording. Findings render as IDE-style underlines with hover explanations, plus a new Checks view in the sidebar (group by change or by check type), a resizable results panel scoped to what you're reading, and severity badges across the app. On by default; Settings → General can disable it or opt archived changes in
+- Repositories with large git histories load dramatically faster: authorship now comes from a single history walk instead of one per file (a 4,500-commit repo with 2,800 specs went from hanging indefinitely to about 4 seconds)
+- Only one right panel (comments, spec checks, AI summary) stays open at a time
+- Updated dependencies: Vite 8, TypeScript 7, React plugin 6, js-yaml 5
+
 ## [1.1.3](https://github.com/dansreis/speclens/compare/v1.1.2...v1.1.3) - 2026-07-14
 
 - Fixed the Linux AppImage failing to start on Wayland with `EGL_BAD_PARAMETER`: the app now preloads the system Wayland client library instead of the bundled one and disables unstable WebKitGTK rendering paths inside AppImages (#13)

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
 	"name": "speclens",
 	"private": true,
-	"version": "1.1.3",
+	"version": "1.2.0",
 	"type": "module",
 	"packageManager": "pnpm@11.4.0",
 	"scripts": {

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -4133,7 +4133,7 @@ dependencies = [
 
 [[package]]
 name = "speclens"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "encoding_rs",
  "git2",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "speclens"
-version = "1.1.3"
+version = "1.2.0"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
 	"$schema": "https://schema.tauri.app/config/2",
 	"productName": "SpecLens",
-	"version": "1.1.3",
+	"version": "1.2.0",
 	"identifier": "com.danielreis.speclens",
 	"build": {
 		"beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
Minor release: spec checks (beta), large-repo loading fix, dependency updates.

Merging bumps package.json on main, which triggers the Release workflow (build all platforms, tag v1.2.0, publish the GitHub release with the changelog section as notes).